### PR TITLE
Hotfix - Fix collection moving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed [Issue 19](https://github.com/getcandy/getcandy/issues/19)
 - Fixed [Issue 18](https://github.com/getcandy/getcandy/issues/18), wrong name on Activity Log
+- Fixed [Issue 23](https://github.com/getcandy/getcandy/issues/23)
 
 ## 2.0-beta4 - 2021-12-24
 ### Fixed

--- a/resources/views/livewire/components/collections/collection-groups/show.blade.php
+++ b/resources/views/livewire/components/collections/collection-groups/show.blade.php
@@ -103,7 +103,7 @@
           @endif
         </x-slot>
         <x-slot name="footer">
-          <x-hub::button type="button" wire:click="moveCollection" :disabled="!$this->sourceCollection && !$this->targetCollection">
+          <x-hub::button type="button" wire:click="moveCollection" :disabled="!$this->targetCollection">
             {{ __('adminhub::catalogue.collections.groups.move.btn') }}
           </x-hub::button>
         </x-slot>

--- a/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
+++ b/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
@@ -228,7 +228,7 @@ class CollectionGroupShow extends Component
         }
 
         return Collection::search($this->searchTerm)
-            ->get();
+            ->get()->filter(fn($collection) => $collection->id != $this->collectionMove['source']);
     }
 
     /**


### PR DESCRIPTION
Fixes #23 

Issue seemed to be that you could try and move a collection into one that didn't exist as the button was not disabling properly.

This should be fixed in this PR and also we now filter out the source collection from search results.