### PR TITLE
Hotfix/fix product type switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fixed [Issue 19](https://github.com/getcandy/getcandy/issues/19)
 - Fixed [Issue 18](https://github.com/getcandy/getcandy/issues/18), wrong name on Activity Log
+- Fixed [Issue 4](https://github.com/getcandy/getcandy/issues/4)
 
 ## 2.0-beta4 - 2021-12-24
 ### Fixed

--- a/src/Http/Livewire/Traits/WithAttributes.php
+++ b/src/Http/Livewire/Traits/WithAttributes.php
@@ -38,7 +38,7 @@ trait WithAttributes
 
     protected function mapAttributes()
     {
-        $this->attributeMapping = $this->availableAttributes->map(function ($attribute, $index) {
+        $this->attributeMapping = $this->availableAttributes->mapWithKeys(function ($attribute, $index) {
             $data = $this->attributeData ?
                 $this->attributeData->first(fn ($value, $handle) => $handle == $attribute->handle)
                 : null;
@@ -49,12 +49,12 @@ trait WithAttributes
                 $value = $this->prepareTranslatedText($value);
             }
 
-            return [
+            return [$attribute->id => [
                 'name' => $attribute->translate('name'),
                 'group' => $attribute->attributeGroup->translate('name'),
                 'group_handle' => $attribute->attributeGroup->handle,
                 'id' => $attribute->handle,
-                'signature' => 'attributeMapping.'.$index.'.data',
+                'signature' => 'attributeMapping.'.$attribute->id.'.data',
                 'type' => $attribute->type,
                 'handle' => $attribute->handle,
                 'configuration' => $attribute->configuration,
@@ -63,7 +63,7 @@ trait WithAttributes
                     $attribute->type
                 )),
                 'data' => $value,
-            ];
+            ]];
         });
     }
 

--- a/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
+++ b/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
@@ -252,10 +252,10 @@ class ProductShowTest extends TestCase
         ]);
 
         // Need some attributes...
-        Attribute::factory()->create([
+        $name = Attribute::factory()->create([
             'handle' => 'name',
         ]);
-        Attribute::factory()->create([
+        $description = Attribute::factory()->create([
             'handle' => 'description',
         ]);
 
@@ -282,8 +282,8 @@ class ProductShowTest extends TestCase
         $component = LiveWire::actingAs($staff, 'staff')
             ->test(ProductShow::class, [
                 'product' => $product->refresh(),
-            ])->set('attributeMapping.0.data', 'nouseforaname')
-            ->set('attributeMapping.1.data', 'nouseforadescription');
+            ])->set('attributeMapping.'.$name->id.'.data', 'nouseforaname')
+            ->set('attributeMapping.'.$description->id.'.data', 'nouseforadescription');
 
         $component->call('save')->assertHasNoErrors();
 


### PR DESCRIPTION
Fixes #4 

Before, when mapping attributes it was using the loop index to determine the position in the array for `wire:model`. This was causing issues with Alpinejs when switching product type and a different set of attributes get loaded in. Specifically it was `@entangle` on the rich text input having issues.

I've found by using the `$attribute->id` for the mapping fixes this issue and since attributes will all have unique ID's this shouldn't cause any problems.