### PR TITLE
Move auth guard reg to service provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fixed [Issue 19](https://github.com/getcandy/getcandy/issues/19)
 - Fixed [Issue 18](https://github.com/getcandy/getcandy/issues/18), wrong name on Activity Log
 
+### Changed
+- Removed requirement to specify `staff` guard in `config/auth.php`. This can be safely removed.
+
 ## 2.0-beta4 - 2021-12-24
 ### Fixed
 - Fixed group by statement on dashboard query by [@itcyborg](https://github.com/itcyborg)

--- a/src/AdminHubServiceProvider.php
+++ b/src/AdminHubServiceProvider.php
@@ -99,6 +99,7 @@ class AdminHubServiceProvider extends ServiceProvider
         });
 
         $this->registerLivewireComponents();
+        $this->registerAuthGuard();
         $this->registerPermissionManifest();
         $this->registerPublishables();
 
@@ -291,6 +292,18 @@ class AdminHubServiceProvider extends ServiceProvider
         $this->publishes([
             __DIR__.'/../public' => public_path('vendor/getcandy/admin-hub/'),
         ], 'getcandy:hub:public');
+    }
+
+    /**
+     * Register our auth guard.
+     *
+     * @return void
+     */
+    protected function registerAuthGuard()
+    {
+        $this->app['config']->set('auth.guards.staff', [
+            'driver' => 'getcandyhub',
+        ]);
     }
 
     /**


### PR DESCRIPTION
This will remove the need to manually register the `staff` auth guard in `config/auth.php`