### PR TITLE
Implement jsonSerialize to TranslatedText

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+- `TranslatedText` fieldtype now implements `JsonSerializable` interface ([#50](https://github.com/getcandy/getcandy/issues/50))
+
 ## 2.0-beta5 - 2022-01-10
 
 ### Fixes

--- a/packages/core/src/FieldTypes/TranslatedText.php
+++ b/packages/core/src/FieldTypes/TranslatedText.php
@@ -5,8 +5,9 @@ namespace GetCandy\FieldTypes;
 use GetCandy\Base\FieldType;
 use GetCandy\Exceptions\FieldTypeException;
 use Illuminate\Database\Eloquent\Collection;
+use JsonSerializable;
 
-class TranslatedText implements FieldType
+class TranslatedText implements FieldType, JsonSerializable
 {
     /**
      * @var Illuminate\Database\Eloquent\Collection
@@ -25,6 +26,16 @@ class TranslatedText implements FieldType
         } else {
             $this->value = new Collection();
         }
+    }
+
+    /**
+     * Serialize the class.
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 
     /**

--- a/packages/core/tests/Unit/FieldTypes/TranslatedTextTest.php
+++ b/packages/core/tests/Unit/FieldTypes/TranslatedTextTest.php
@@ -35,6 +35,25 @@ class TranslatedTextTest extends TestCase
     }
 
     /** @test */
+    public function can_json_encode_fieldtype()
+    {
+        $data = [
+            'en' => 'Blue',
+            'fr' => 'Bleu',
+        ];
+
+        $field = new TranslatedText(collect([
+            'en' => new Text('Blue'),
+            'fr' => new Text('Bleu'),
+        ]));
+
+        $this->assertSame(
+            json_encode($data),
+            json_encode($field)
+        );
+    }
+
+    /** @test */
     public function check_does_not_allow_non_text_field_types()
     {
         $this->assertTrue(true);


### PR DESCRIPTION
Fixes #50 

This PR looks to add the `jsonSerialize` method to the `TranslatedText` fieldtype. Currently when Laravel outputs something like a JSON response when building an API the result will be an empty object where the attribute values should be. This should fix that.