### PR TITLE
Change slugs to use underscore https://github.com/getcandy/getcandy/issues/81

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -134,7 +134,7 @@ class AttributeEdit extends Component
      */
     public function updatedAttributeHandle()
     {
-        $this->attribute->handle = Str::slug($this->attribute->handle,'_');
+        $this->attribute->handle = Str::slug($this->attribute->handle, '_');
     }
 
     public function formatHandle()

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -134,14 +134,15 @@ class AttributeEdit extends Component
      */
     public function updatedAttributeHandle()
     {
-        $this->attribute->handle = Str::slug($this->attribute->handle);
+        $this->attribute->handle = Str::slug($this->attribute->handle,'_');
     }
 
     public function formatHandle()
     {
         if (!$this->manualHandle && !$this->attribute->handle) {
             $this->attribute->handle = Str::slug(
-                $this->attribute->name[$this->defaultLanguage->code] ?? null
+                $this->attribute->name[$this->defaultLanguage->code] ?? null,
+                '_'
             );
         }
     }


### PR DESCRIPTION
Update how handle is generated when creating an attribute. This is to prevent issues when parsing the attributes in javascript without adding additional mapping using php.
case : suppose we want to add an attribute named "warranty information", the handle generated will be 'warranty-information'. this commit attempts to fix this by replacing '-' with '_'