### PR TITLE
Change slugs to use underscore

### DIFF
--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -68,6 +68,7 @@ use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
 use Livewire\Livewire;
+use Illuminate\Support\Str;
 
 class AdminHubServiceProvider extends ServiceProvider
 {
@@ -130,6 +131,11 @@ class AdminHubServiceProvider extends ServiceProvider
             RouteMatched::class,
             [SetStaffAuthMiddlewareListener::class, 'handle']
         );
+
+        // Handle generator
+        Str::macro('handle',function($string){
+            return Str::slug($string, '_');
+        });
 
         $this->app->singleton(\GetCandy\Hub\Editing\ProductSection::class, function ($app) {
             return new \GetCandy\Hub\Editing\ProductSection();

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -67,8 +67,8 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
-use Livewire\Livewire;
 use Illuminate\Support\Str;
+use Livewire\Livewire;
 
 class AdminHubServiceProvider extends ServiceProvider
 {

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -133,7 +133,7 @@ class AdminHubServiceProvider extends ServiceProvider
         );
 
         // Handle generator
-        Str::macro('handle', function ($string){
+        Str::macro('handle', function ($string) {
             return Str::slug($string, '_');
         });
 

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -133,7 +133,7 @@ class AdminHubServiceProvider extends ServiceProvider
         );
 
         // Handle generator
-        Str::macro('handle',function($string){
+        Str::macro('handle', function($string){
             return Str::slug($string, '_');
         });
 

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -132,11 +132,6 @@ class AdminHubServiceProvider extends ServiceProvider
             [SetStaffAuthMiddlewareListener::class, 'handle']
         );
 
-        // Handle generator
-        Str::macro('handle', function ($string) {
-            return Str::slug($string, '_');
-        });
-
         $this->app->singleton(\GetCandy\Hub\Editing\ProductSection::class, function ($app) {
             return new \GetCandy\Hub\Editing\ProductSection();
         });

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -133,7 +133,7 @@ class AdminHubServiceProvider extends ServiceProvider
         );
 
         // Handle generator
-        Str::macro('handle', function($string){
+        Str::macro('handle', function ($string){
             return Str::slug($string, '_');
         });
 

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -67,7 +67,6 @@ use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\ServiceProvider;
-use Illuminate\Support\Str;
 use Livewire\Livewire;
 
 class AdminHubServiceProvider extends ServiceProvider

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
@@ -30,7 +30,7 @@ abstract class AbstractAttribute extends Component
     public function generateHandle($value)
     {
         if ($value && !$this->manualHandle) {
-            $this->attribute->handle = Str::slug($value);
+            $this->attribute->handle = Str::slug($value,'_');
         }
     }
 

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
@@ -30,7 +30,7 @@ abstract class AbstractAttribute extends Component
     public function generateHandle($value)
     {
         if ($value && !$this->manualHandle) {
-            $this->attribute->handle = Str::slug($value,'_');
+            $this->attribute->handle = Str::slug($value, '_');
         }
     }
 

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
@@ -28,7 +28,6 @@ abstract class AbstractAttribute extends Component
      */
     public function generateHandle($value)
     {
-
         if ($value && ! $this->manualHandle) {
             $this->attribute->handle = Str::handle($value);
         }

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
@@ -29,7 +29,7 @@ abstract class AbstractAttribute extends Component
     public function generateHandle($value)
     {
 
-        if ($value && !$this->manualHandle) {
+        if ($value && ! $this->manualHandle) {
             $this->attribute->handle = Str::handle($value);
         }
     }

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AbstractAttribute.php
@@ -30,7 +30,7 @@ abstract class AbstractAttribute extends Component
     public function generateHandle($value)
     {
         if ($value && !$this->manualHandle) {
-            $this->attribute->handle = Str::slug($value, '_');
+            $this->attribute->handle = Str::handle($value);
         }
     }
 

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -134,15 +134,14 @@ class AttributeEdit extends Component
      */
     public function updatedAttributeHandle()
     {
-        $this->attribute->handle = Str::slug($this->attribute->handle, '_');
+        $this->attribute->handle = Str::handle($this->attribute->handle);
     }
 
     public function formatHandle()
     {
         if (!$this->manualHandle && !$this->attribute->handle) {
-            $this->attribute->handle = Str::slug(
-                $this->attribute->name[$this->defaultLanguage->code] ?? null,
-                '_'
+            $this->attribute->handle = Str::handle(
+                $this->attribute->name[$this->defaultLanguage->code] ?? null
             );
         }
     }

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -134,7 +134,7 @@ class AttributeEdit extends Component
      */
     public function updatedAttributeHandle()
     {
-        $this->attribute->handle = Str::slug($this->attribute->handle,'_');
+        $this->attribute->handle = Str::slug($this->attribute->handle, '_');
     }
 
     public function formatHandle()

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -139,7 +139,7 @@ class AttributeEdit extends Component
 
     public function formatHandle()
     {
-        if (!$this->manualHandle && ! $this->attribute->handle) {
+        if (! $this->manualHandle && ! $this->attribute->handle) {
             $this->attribute->handle = Str::handle(
                 $this->attribute->name[$this->defaultLanguage->code] ?? null
             );

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -139,7 +139,7 @@ class AttributeEdit extends Component
 
     public function formatHandle()
     {
-        if (!$this->manualHandle && !$this->attribute->handle) {
+        if (!$this->manualHandle && ! $this->attribute->handle) {
             $this->attribute->handle = Str::handle(
                 $this->attribute->name[$this->defaultLanguage->code] ?? null
             );

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeEdit.php
@@ -134,14 +134,15 @@ class AttributeEdit extends Component
      */
     public function updatedAttributeHandle()
     {
-        $this->attribute->handle = Str::slug($this->attribute->handle);
+        $this->attribute->handle = Str::slug($this->attribute->handle,'_');
     }
 
     public function formatHandle()
     {
         if (!$this->manualHandle && !$this->attribute->handle) {
             $this->attribute->handle = Str::slug(
-                $this->attribute->name[$this->defaultLanguage->code] ?? null
+                $this->attribute->name[$this->defaultLanguage->code] ?? null,
+                '_'
             );
         }
     }

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -60,7 +60,7 @@ class AttributeGroupEdit extends Component
     {
         $this->validate();
 
-        $handle = Str::snake("{$this->typeHandle}_{$this->attributeGroup->translate('name')}");
+        $handle = Str::handle("{$this->typeHandle}_{$this->attributeGroup->translate('name')}");
         $this->attributeGroup->handle = $handle;
 
         $this->validate([

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -114,6 +114,11 @@ class GetCandyServiceProvider extends ServiceProvider
         }
 
         Arr::macro('permutate', [\GetCandy\Utils\Arr::class, 'permutate']);
+        
+        // Handle generator
+        Str::macro('handle', function ($string) {
+            return Str::slug($string, '_');
+        });
 
         Converter::setMeasurements(
             config('getcandy.shipping.measurements', [])

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -48,6 +48,7 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 
 class GetCandyServiceProvider extends ServiceProvider
 {
@@ -114,7 +115,7 @@ class GetCandyServiceProvider extends ServiceProvider
         }
 
         Arr::macro('permutate', [\GetCandy\Utils\Arr::class, 'permutate']);
-        
+
         // Handle generator
         Str::macro('handle', function ($string) {
             return Str::slug($string, '_');

--- a/packages/core/tests/Utils/StrTest.php
+++ b/packages/core/tests/Utils/StrTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Utils;
+
+use GetCandy\Tests\TestCase;
+use Illuminate\Support\Str;
+
+/**
+ * @group core.utils
+ */
+class StrTest extends TestCase
+{
+    /** @test */
+    public function passing_kebab_case_string()
+    {
+        $this->assertEquals('foo_bar', Str::handle('foo-bar'));
+    }
+
+    /** @test */
+    public function passing_sentence_string()
+    {
+        $this->assertEquals('foo_bar', Str::handle('foo bar'));
+    }
+
+    /** @test */
+    public function passing_mixed_sentence_and_kebab_case()
+    {
+        $this->assertEquals('foo_bar_foo_bar', Str::handle('foo-bar foo bar'));
+    }
+}


### PR DESCRIPTION
Update how handle is generated when creating an attribute. This is to prevent issues when parsing the attributes in javascript without adding additional mapping using php.
case : suppose we want to add an attribute named "warranty information", the handle generated will be 'warranty-information'. this commit attempts to fix this by replacing '-' with '_'