### PR TITLE
Bug: Don't assume user has a customer associated yet

### DIFF
--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -94,9 +94,10 @@ class GetCandyServiceProvider extends ServiceProvider
         $this->registerObservers();
         $this->registerAddonManifest();
         $this->registerBlueprintMacros();
-        
+
         config('auth.providers.users.model')::resolveRelationUsing('customers', function ($userModel) {
             $prefix = config('getcandy.database.table_prefix');
+
             return $userModel->belongsToMany(
                 Customer::class,
                 "{$prefix}customer_user"

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -29,7 +29,6 @@ use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Collection;
 use GetCandy\Models\Currency;
-use GetCandy\Models\Customer;
 use GetCandy\Models\Language;
 use GetCandy\Models\OrderLine;
 use GetCandy\Models\Url;
@@ -94,15 +93,6 @@ class GetCandyServiceProvider extends ServiceProvider
         $this->registerObservers();
         $this->registerAddonManifest();
         $this->registerBlueprintMacros();
-
-        config('auth.providers.users.model')::resolveRelationUsing('customers', function ($userModel) {
-            $prefix = config('getcandy.database.table_prefix');
-
-            return $userModel->belongsToMany(
-                Customer::class,
-                "{$prefix}customer_user"
-            )->withTimestamps();
-        });
 
         if (!$this->app->environment('testing')) {
             $this->registerStateListeners();

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -29,6 +29,7 @@ use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Collection;
 use GetCandy\Models\Currency;
+use GetCandy\Models\Customer;
 use GetCandy\Models\Language;
 use GetCandy\Models\OrderLine;
 use GetCandy\Models\Url;
@@ -93,6 +94,14 @@ class GetCandyServiceProvider extends ServiceProvider
         $this->registerObservers();
         $this->registerAddonManifest();
         $this->registerBlueprintMacros();
+        
+        config('auth.providers.users.model')::resolveRelationUsing('customers', function ($userModel) {
+            $prefix = config('getcandy.database.table_prefix');
+            return $userModel->belongsToMany(
+                Customer::class,
+                "{$prefix}customer_user"
+            )->withTimestamps();
+        });
 
         if (!$this->app->environment('testing')) {
             $this->registerStateListeners();

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -52,7 +52,7 @@ class CartManager
     public function __construct(
         protected Cart $cart,
     ) {
-        $this->customerGroups = $cart->user && $cart->user->customers ?
+        $this->customerGroups = $cart->user && $cart->user->customers->count() ?
             $cart->user->customers->map(function ($customer) {
                 return $customer->customerGroups;
             })->flatten()

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -52,7 +52,7 @@ class CartManager
     public function __construct(
         protected Cart $cart,
     ) {
-        $this->customerGroups = $cart->user ?
+        $this->customerGroups = $cart->user && $cart->user->customers ?
             $cart->user->customers->map(function ($customer) {
                 return $customer->customerGroups;
             })->flatten()

--- a/packages/core/tests/Stubs/User.php
+++ b/packages/core/tests/Stubs/User.php
@@ -2,12 +2,14 @@
 
 namespace GetCandy\Tests\Stubs;
 
+use GetCandy\Base\Traits\GetCandyUser;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
+    use GetCandyUser;
     use HasFactory;
     use Notifiable;
 

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -8,9 +8,10 @@ use GetCandy\Models\Channel;
 use GetCandy\Models\Currency;
 use GetCandy\Models\Customer;
 use GetCandy\Models\ProductVariant;
-use GetCandy\Tests\Stubs\User;
+use GetCandy\Tests\Stubs\User as StubUser;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
 
 /**
  * @group getcandy.carts
@@ -18,6 +19,11 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 class CartTest extends TestCase
 {
     use RefreshDatabase;
+    
+    private function setAuthUserConfig()
+    {
+        Config::set('auth.providers.users.model', 'GetCandy\Tests\Stubs\User');
+    }
 
     /** @test */
     public function can_make_a_cart()
@@ -66,9 +72,11 @@ class CartTest extends TestCase
     /** @test */
     public function can_associate_cart_with_user_with_no_customer_attached()
     {
+        $this->setAuthUserConfig();
+
         $currency = Currency::factory()->create();
         $channel = Channel::factory()->create();
-        $user = User::factory()->create();
+        $user = StubUser::factory()->create();
 
         $cart = Cart::create([
             'currency_id' => $currency->id,
@@ -82,9 +90,11 @@ class CartTest extends TestCase
     /** @test */
     public function can_associate_cart_with_user_with_customer_attached()
     {
+        $this->setAuthUserConfig();
+
         $currency = Currency::factory()->create();
         $channel = Channel::factory()->create();
-        $user = User::factory()->create();
+        $user = StubUser::factory()->create();
         $customer = Customer::factory()->create();
 
         $customer->users()->attach($user);
@@ -97,4 +107,6 @@ class CartTest extends TestCase
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
     }
+    
+    
 }

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -6,7 +6,9 @@ use GetCandy\Managers\CartManager;
 use GetCandy\Models\Cart;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Currency;
+use GetCandy\Models\Customer;
 use GetCandy\Models\ProductVariant;
+use GetCandy\Tests\Stubs\User;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -58,6 +60,41 @@ class CartTest extends TestCase
         ]);
 
         // dd(CartManager::class);
+        $this->assertInstanceOf(CartManager::class, $cart->getManager());
+    }
+    
+    /** @test */
+    public function can_associate_cart_with_user_with_no_customer_attached()
+    {
+        $currency = Currency::factory()->create();
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+
+        $cart = Cart::create([
+            'currency_id' => $currency->id,
+            'channel_id'  => $channel->id,
+            'user_id' => $user->id,
+        ]);
+
+        $this->assertInstanceOf(CartManager::class, $cart->getManager());
+    }
+    
+    /** @test */
+    public function can_associate_cart_with_user_with_customer_attached()
+    {
+        $currency = Currency::factory()->create();
+        $channel = Channel::factory()->create();
+        $user = User::factory()->create();
+        $customer = Customer::factory()->create();
+            
+        $customer->users()->attach($user);
+
+        $cart = Cart::create([
+            'currency_id' => $currency->id,
+            'channel_id'  => $channel->id,
+            'user_id' => $user->id,
+        ]);
+
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
     }
 }

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -19,7 +19,7 @@ use Illuminate\Support\Facades\Config;
 class CartTest extends TestCase
 {
     use RefreshDatabase;
-    
+
     private function setAuthUserConfig()
     {
         Config::set('auth.providers.users.model', 'GetCandy\Tests\Stubs\User');
@@ -107,6 +107,4 @@ class CartTest extends TestCase
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
     }
-    
-    
 }

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -62,7 +62,7 @@ class CartTest extends TestCase
         // dd(CartManager::class);
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
     }
-    
+
     /** @test */
     public function can_associate_cart_with_user_with_no_customer_attached()
     {
@@ -73,12 +73,12 @@ class CartTest extends TestCase
         $cart = Cart::create([
             'currency_id' => $currency->id,
             'channel_id'  => $channel->id,
-            'user_id' => $user->id,
+            'user_id'     => $user->id,
         ]);
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
     }
-    
+
     /** @test */
     public function can_associate_cart_with_user_with_customer_attached()
     {
@@ -92,7 +92,7 @@ class CartTest extends TestCase
         $cart = Cart::create([
             'currency_id' => $currency->id,
             'channel_id'  => $channel->id,
-            'user_id' => $user->id,
+            'user_id'     => $user->id,
         ]);
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -86,7 +86,7 @@ class CartTest extends TestCase
         $channel = Channel::factory()->create();
         $user = User::factory()->create();
         $customer = Customer::factory()->create();
-            
+
         $customer->users()->attach($user);
 
         $cart = Cart::create([


### PR DESCRIPTION
Installed into an existing Laravel app and the trying to `CartSession::current()` I got an error on this line as my user (logged in) had no customer associated with it (yet).

This fix should cover that offer.