### PR TITLE
Feature - Pricing manager

### DIFF
--- a/docs/src/getcandy/products.md
+++ b/docs/src/getcandy/products.md
@@ -450,6 +450,79 @@ Price::create([
 
 In the above example if you order between 1 and 9 items you will pay `1.99` per item. But if you order at least 10 you will pay `1.50` per item.
 
+### Fetching the price
+
+Once you've got your pricing all set up, you're likely going to want to display it on your storefront. We've created a `PricingManager` which is available via a facade to make this process as painless as possible.
+
+To get the pricing for a product you can simple use the following helpers:
+
+#### Minimum example
+
+A quantity of 1 is implied when not passed.
+
+```php
+$pricing = \GetCandy\Facades\Pricing::for($variant);
+```
+
+#### With Quantities
+```php
+$pricing = \GetCandy\Facades\Pricing::qty(5)->for($variant);
+```
+
+#### With Customer Groups
+
+If you don't pass in a customer group, GetCandy will use the default, including any pricing that isn't specific to a customer group.
+
+```php
+$pricing = \GetCandy\Facades\Pricing::customerGroups($groups)->for($variant);
+
+// Or a single customer group
+$pricing = \GetCandy\Facades\Pricing::customerGroup($group)->for($variant);
+```
+
+#### Specific to a user
+```php
+$pricing = \GetCandy\Facades\Pricing::user($user)->for($variant);
+```
+
+#### With a specific currency
+
+If you don't pass in a currency, the default is implied.
+
+```php
+$pricing = \GetCandy\Facades\Pricing::currency($currency)->for($variant);
+```
+
+::: danger Be aware
+If you try and fetch a price for a currency that doesn't exist, a ` GetCandy\Exceptions\MissingCurrencyPriceException` exception will be thrown.
+:::
+
+---
+
+This will return a `PricingResponse` object which you can interact with to display the correct prices. Unless it's a collection, each property will return a `GetCandy\Models\Price` object.
+
+```php
+/**
+ * The price that was matched given the criteria.
+ */
+$pricing->matched;
+
+/**
+ * The base price associated to the variant.
+ */
+$pricing->base;
+
+/**
+ * A collection of all the price tiers available for the given criteria.
+ */
+$pricing->tiers;
+
+/**
+ * All customer group pricing available for the given criteria.
+ */
+$pricing->customerGroupPrices;
+```
+
 ## Full Example
 
 For this example, we're going to be creating some Dr. Martens boots. Below is a screenshot of what we're aiming for:

--- a/packages/core/src/Actions/Carts/CalculateLine.php
+++ b/packages/core/src/Actions/Carts/CalculateLine.php
@@ -4,6 +4,7 @@ namespace GetCandy\Actions\Carts;
 
 use GetCandy\Base\Addressable;
 use GetCandy\DataTypes\Price;
+use GetCandy\Facades\Pricing;
 use GetCandy\Managers\TaxManager;
 use GetCandy\Models\CartLine;
 use Illuminate\Support\Collection;
@@ -34,8 +35,14 @@ class CalculateLine
         $cart = $cartLine->cart;
         $unitQuantity = $purchasable->getUnitQuantity();
 
+        $priceResponse = Pricing::currency($cart->currency)
+            ->qty($cartLine->quantity)
+            ->currency($cart->currency)
+            ->customerGroups($customerGroups)
+            ->for($purchasable);
+
         $price = new Price(
-            $purchasable->getPrice($cartLine->quantity, $cart->currency, $customerGroups),
+            $priceResponse->matched->price->value,
             $cart->currency,
             $purchasable->getUnitQuantity()
         );

--- a/packages/core/src/Base/DataTransferObjects/PricingResponse.php
+++ b/packages/core/src/Base/DataTransferObjects/PricingResponse.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace GetCandy\Base\DataTransferObjects;
+
+use GetCandy\Models\Price;
+use Illuminate\Support\Collection;
+
+class PricingResponse
+{
+    public function __construct(
+        public Price $matched,
+        public Price $base,
+        public Collection $tiered,
+        public Collection $customerGroupPrices,
+    ) {
+        //
+    }
+}

--- a/packages/core/src/Base/PricingManagerInterface.php
+++ b/packages/core/src/Base/PricingManagerInterface.php
@@ -2,6 +2,64 @@
 
 namespace GetCandy\Base;
 
+use GetCandy\Models\Currency;
+use GetCandy\Models\CustomerGroup;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Support\Collection;
+
 interface PricingManagerInterface
 {
+    /**
+     * Set the user property.
+     *
+     * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     *
+     * @return self
+     */
+    public function user(Authenticatable $user);
+
+    /**
+     * Set the currency property.
+     *
+     * @param \GetCandy\Models\Currency $currency
+     *
+     * @return self
+     */
+    public function currency(Currency $currency);
+
+    /**
+     * Set the quantity property.
+     *
+     * @param int $qty
+     *
+     * @return self
+     */
+    public function qty(int $qty);
+
+    /**
+     * Set the customer groups.
+     *
+     * @param Collection $customerGroups
+     *
+     * @return self
+     */
+    public function customerGroups(Collection $customerGroups);
+
+    /**
+     * Set the customer group.
+     *
+     * @param CustomerGroup $customerGroup
+     *
+     * @return self
+     */
+    public function customerGroup(CustomerGroup $customerGroup);
+
+    /**
+     * Get the price for a purchasable.
+     *
+     * @param Purchasable $purchasable
+     *
+     * @return \GetCandy\Base\DataTransferObjects\PricingResponse
+     */
+    public function for(Purchasable $purchasable);
 }

--- a/packages/core/src/Base/PricingManagerInterface.php
+++ b/packages/core/src/Base/PricingManagerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace GetCandy\Base;
+
+interface PricingManagerInterface
+{
+
+}

--- a/packages/core/src/Base/PricingManagerInterface.php
+++ b/packages/core/src/Base/PricingManagerInterface.php
@@ -4,5 +4,4 @@ namespace GetCandy\Base;
 
 interface PricingManagerInterface
 {
-
 }

--- a/packages/core/src/Base/Purchasable.php
+++ b/packages/core/src/Base/Purchasable.php
@@ -10,7 +10,7 @@ interface Purchasable
     /**
      * Get the purchasable prices.
      *
-     * @return Collection
+     * @return \Illuminate\Support\Collection<\GetCandy\Models\Price>
      */
     public function getPrices(): Collection;
 

--- a/packages/core/src/Base/Purchasable.php
+++ b/packages/core/src/Base/Purchasable.php
@@ -19,6 +19,13 @@ interface Purchasable
     public function getPrice(int $quantity, Currency $currency, Collection $customerGroups): int;
 
     /**
+     * Get the purchasable prices.
+     *
+     * @return Collection
+     */
+    public function getPrices(): Collection;
+
+    /**
      * Return the purchasable unit quantity.
      *
      * @return int

--- a/packages/core/src/Base/Purchasable.php
+++ b/packages/core/src/Base/Purchasable.php
@@ -2,22 +2,11 @@
 
 namespace GetCandy\Base;
 
-use GetCandy\Models\Currency;
 use GetCandy\Models\TaxClass;
 use Illuminate\Support\Collection;
 
 interface Purchasable
 {
-    /**
-     * Get the price for the purchasable item.
-     *
-     * @param int        $quantity
-     * @param Collection $customerGroups
-     *
-     * @return int
-     */
-    public function getPrice(int $quantity, Currency $currency, Collection $customerGroups): int;
-
     /**
      * Get the purchasable prices.
      *

--- a/packages/core/src/DataTypes/ShippingOption.php
+++ b/packages/core/src/DataTypes/ShippingOption.php
@@ -33,6 +33,11 @@ class ShippingOption implements Purchasable
         return $this->price->value;
     }
 
+    public function getPrices(): Collection
+    {[
+        return collect();
+    ]}
+
     /**
      * Return the purchasable unit quantity.
      *

--- a/packages/core/src/DataTypes/ShippingOption.php
+++ b/packages/core/src/DataTypes/ShippingOption.php
@@ -34,9 +34,9 @@ class ShippingOption implements Purchasable
     }
 
     public function getPrices(): Collection
-    {[
+    {
         return collect();
-    ]}
+    }
 
     /**
      * Return the purchasable unit quantity.

--- a/packages/core/src/Facades/Pricing.php
+++ b/packages/core/src/Facades/Pricing.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace GetCandy\Facades;
+
+use GetCandy\Base\PricingManagerInterface;
+use Illuminate\Support\Facades\Facade;
+
+class Pricing extends Facade
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected static function getFacadeAccessor()
+    {
+        return PricingManagerInterface::class;
+    }
+}

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -157,7 +157,7 @@ class GetCandyServiceProvider extends ServiceProvider
             return $app->make(FieldTypeManifest::class);
         });
 
-        $this->app->singleton(PricingManagerInterface::class, function ($app) {
+        $this->app->bind(PricingManagerInterface::class, function ($app) {
             return $app->make(PricingManager::class);
         });
 

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -14,6 +14,7 @@ use GetCandy\Base\FieldTypeManifestInterface;
 use GetCandy\Base\OrderModifiers;
 use GetCandy\Base\OrderReferenceGenerator;
 use GetCandy\Base\OrderReferenceGeneratorInterface;
+use GetCandy\Base\PricingManagerInterface;
 use GetCandy\Base\ShippingManifest;
 use GetCandy\Base\ShippingManifestInterface;
 use GetCandy\Base\ShippingModifiers;
@@ -25,6 +26,7 @@ use GetCandy\Database\State\ConvertProductTypeAttributesToProducts;
 use GetCandy\Database\State\EnsureDefaultTaxClassExists;
 use GetCandy\Listeners\CartSessionAuthListener;
 use GetCandy\Managers\CartSessionManager;
+use GetCandy\Managers\PricingManager;
 use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Collection;
@@ -153,6 +155,10 @@ class GetCandyServiceProvider extends ServiceProvider
 
         $this->app->singleton(FieldTypeManifestInterface::class, function ($app) {
             return $app->make(FieldTypeManifest::class);
+        });
+
+        $this->app->singleton(PricingManagerInterface::class, function ($app) {
+            return $app->make(PricingManager::class);
         });
 
         Event::listen(

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -185,11 +185,27 @@ class PricingManager implements PricingManagerInterface
 
         $matched = $tieredPricing->first() ?: $matched;
 
-        return new PricingResponse(
+        $response = new PricingResponse(
             matched: $matched,
             base: $prices->first(fn ($price)                 => $price->tier == 1),
             tiered: $prices->filter(fn ($price)              => $price->tier > 1),
             customerGroupPrices: $prices->filter(fn ($price) => (bool) $price->customer_group_id)
         );
+
+        $this->reset();
+
+        return $response;
+    }
+
+    /**
+     * Reset the manager into a base instance.
+     *
+     * @return void
+     */
+    private function reset()
+    {
+        $this->qty = 1;
+        $this->user = null;
+        $this->customerGroups = null;
     }
 }

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -154,7 +154,7 @@ class PricingManager implements PricingManagerInterface
         });
 
         if (!$currencyPrices->count()) {
-            throw new MissingCurrencyPriceException;
+            throw new MissingCurrencyPriceException();
         }
 
         $prices = $currencyPrices->filter(function ($price) {

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Collection;
 class PricingManager implements PricingManagerInterface
 {
     /**
-     * The instance of the user
+     * The instance of the user.
      *
      * @var \Illuminate\Contracts\Auth\Authenticatable
      */
@@ -29,7 +29,7 @@ class PricingManager implements PricingManagerInterface
     /**
      * The quantity value.
      *
-     * @var integer
+     * @var int
      */
     protected int $qty = 1;
 
@@ -51,11 +51,13 @@ class PricingManager implements PricingManagerInterface
      * Set the user property.
      *
      * @param \Illuminate\Contracts\Auth\Authenticatable $user
+     *
      * @return self
      */
     public function user(Authenticatable $user)
     {
         $this->user = $user;
+
         return $this;
     }
 
@@ -63,23 +65,27 @@ class PricingManager implements PricingManagerInterface
      * Set the currency property.
      *
      * @param \GetCandy\Models\Currency $currency
+     *
      * @return self
      */
     public function currency(Currency $currency)
     {
         $this->currency = $currency;
+
         return $this;
     }
 
     /**
      * Set the quantity property.
      *
-     * @param integer $qty
+     * @param int $qty
+     *
      * @return self
      */
     public function qty(int $qty)
     {
         $this->qty = $qty;
+
         return $this;
     }
 
@@ -87,6 +93,7 @@ class PricingManager implements PricingManagerInterface
      * Set the customer groups.
      *
      * @param Collection $customerGroups
+     *
      * @return self
      */
     public function customerGroups(Collection $customerGroups)
@@ -100,6 +107,7 @@ class PricingManager implements PricingManagerInterface
      * Set the customer group.
      *
      * @param CustomerGroup $customerGroup
+     *
      * @return self
      */
     public function customerGroup(CustomerGroup $customerGroup)
@@ -115,6 +123,7 @@ class PricingManager implements PricingManagerInterface
      * Get the price for a purchasable.
      *
      * @param Purchasable $purchasable
+     *
      * @return \GetCandy\Base\DataTransferObjects\PricingResponse
      */
     public function for(Purchasable $purchasable)
@@ -149,14 +158,14 @@ class PricingManager implements PricingManagerInterface
         })->sortBy('price');
 
         // Get our base price
-        $basePrice = $prices->first(fn($price) => $price->tier == 1 && !$price->customer_group_id);
+        $basePrice = $prices->first(fn ($price) => $price->tier == 1 && !$price->customer_group_id);
 
         // To start, we'll set the matched price to the base price.
         $matched = $basePrice;
 
         // If we have customer group prices, we should find the cheapest one and send that back.
         $potentialGroupPrice = $prices->filter(function ($price) {
-            return !!$price->customer_group_id && $price->tier == 1;
+            return (bool) $price->customer_group_id && $price->tier == 1;
         })->sortBy('price');
 
         $matched = $potentialGroupPrice->first() ?: $matched;
@@ -171,9 +180,9 @@ class PricingManager implements PricingManagerInterface
 
         return new PricingResponse(
             matched: $matched,
-            base: $prices->first(fn($price) => $price->tier == 1),
-            tiered: $prices->filter(fn($price) => $price->tier > 1),
-            customerGroupPrices: $prices->filter(fn($price) => !!$price->customer_group_id)
+            base: $prices->first(fn ($price)                 => $price->tier == 1),
+            tiered: $prices->filter(fn ($price)              => $price->tier > 1),
+            customerGroupPrices: $prices->filter(fn ($price) => (bool) $price->customer_group_id)
         );
     }
 }

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace GetCandy\Managers;
+
+use GetCandy\Base\DataTransferObjects\PricingResponse;
+use GetCandy\Base\PricingManagerInterface;
+use GetCandy\Base\Purchasable;
+use GetCandy\Models\Currency;
+use Illuminate\Auth\Authenticatable;
+
+class PricingManager implements PricingManagerInterface
+{
+    /**
+     * The instance of the user
+     *
+     * @var \Illuminate\Auth\Authenticatable
+     */
+    protected ?Authenticatable $user = null;
+
+    /**
+     * The instance of the currency.
+     *
+     * @var \GetCandy\Models\Currency
+     */
+    protected ?Currency $currency = null;
+
+    /**
+     * The quantity value.
+     *
+     * @var integer
+     */
+    protected int $qty = 1;
+
+    /**
+     * The instance of the purchasable object.
+     *
+     * @var \GetCandy\Base\Purchasable
+     */
+    protected Purchasable $purchasable;
+
+    /**
+     * Set the user property.
+     *
+     * @param \Illuminate\Auth\Authenticatable $user
+     * @return self
+     */
+    public function user(Authenticatable $user)
+    {
+        $this->user = $user;
+        return $this;
+    }
+
+    /**
+     * Set the currency property.
+     *
+     * @param \GetCandy\Models\Currency $currency
+     * @return self
+     */
+    public function currency(Currency $currency)
+    {
+        $this->currency = $currency;
+        return $this;
+    }
+
+    /**
+     * Set the quantity property.
+     *
+     * @param integer $qty
+     * @return self
+     */
+    public function qty(int $qty)
+    {
+        $this->qty = $qty;
+        return $this;
+    }
+
+    /**
+     * Get the price for a purchasable.
+     *
+     * @param Purchasable $purchasable
+     * @return \GetCandy\Base\DataTransferObjects\PricingResponse
+     */
+    public function for(Purchasable $purchasable)
+    {
+        if (!$this->currency) {
+            $this->currency = Currency::getDefault();
+        }
+
+        $prices = $purchasable->getPrices()->filter(function ($price) {
+            return $price->currency_id == $this->currency->id;
+        })->sortBy('price');
+
+        $price = $prices->first(fn($price) => $price->tier <= $this->qty);
+
+        $basePrice = $prices->first(fn($price) => $price->tier == 1);
+
+        $tieredPrices = $prices->filter(fn($price) => $price->tier > 1);
+
+        return new PricingResponse(
+            matched: $price,
+            base: $basePrice,
+            tiered: $tieredPrices,
+            customerGroupPrices: collect()
+        );
+    }
+}

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -123,6 +123,11 @@ class ProductVariant extends BaseModel implements SpatieHasMedia, Purchasable
         return $currencyPrice->price->value;
     }
 
+    public function getPrices(): Collection
+    {
+        return $this->prices;
+    }
+
     /**
      * Return the unit quantity for the variant.
      *

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -10,7 +10,6 @@ use GetCandy\Base\Traits\HasMedia;
 use GetCandy\Base\Traits\HasPrices;
 use GetCandy\Base\Traits\HasTranslations;
 use GetCandy\Database\Factories\ProductVariantFactory;
-use GetCandy\Exceptions\MissingCurrencyPriceException;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Support\Collection;
 use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;

--- a/packages/core/src/Models/ProductVariant.php
+++ b/packages/core/src/Models/ProductVariant.php
@@ -85,44 +85,6 @@ class ProductVariant extends BaseModel implements SpatieHasMedia, Purchasable
         )->withTimestamps();
     }
 
-    /**
-     * Get the price based on quantity and customer groups.
-     *
-     * @param int                            $quantity
-     * @param \Illuminate\Support\Collection $customerGroups
-     *
-     * @return int
-     */
-    public function getPrice(
-        $quantity,
-        Currency $currency,
-        Collection $customerGroups = null
-    ): int {
-        if (!$customerGroups) {
-            $customerGroups = collect();
-        }
-
-        $prices = $this->prices->filter(function ($price) use ($quantity, $customerGroups) {
-            return ($price->tier <= $quantity) && (
-                !$price->customer_group_id || $customerGroups->pluck('id')->contains($price->customer_group_id)
-            );
-        })->sortBy('price');
-
-        $currencyPrice = $prices->first(function ($price) use ($currency) {
-            return $price->currency_id == $currency->id;
-        });
-
-        if (!$currencyPrice) {
-            throw new MissingCurrencyPriceException(
-                __('getcandy::exceptions.missing_currency_price', [
-                    'currency' => $currency->code,
-                ])
-            );
-        }
-
-        return $currencyPrice->price->value;
-    }
-
     public function getPrices(): Collection
     {
         return $this->prices;

--- a/packages/core/tests/Stubs/User.php
+++ b/packages/core/tests/Stubs/User.php
@@ -2,12 +2,14 @@
 
 namespace GetCandy\Tests\Stubs;
 
+use GetCandy\Base\Traits\GetCandyUser;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 
 class User extends Authenticatable
 {
+    use GetCandyUser;
     use HasFactory;
     use Notifiable;
 

--- a/packages/core/tests/Unit/Managers/PricingManagerTest.php
+++ b/packages/core/tests/Unit/Managers/PricingManagerTest.php
@@ -28,10 +28,7 @@ class PricingManagerTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     * @group thisone
-     * */
+    /** @test */
     public function can_set_up_available_guest_pricing()
     {
         $manager = new PricingManager;
@@ -111,20 +108,69 @@ class PricingManagerTest extends TestCase
             'tier'           => 1,
         ]);
 
-        $tiered = Price::factory()->create([
-            'price' => 50,
+        $tiered10 = Price::factory()->create([
+            'price' => 90,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
             'tier'           => 10,
         ]);
 
+        $tiered20 = Price::factory()->create([
+            'price' => 80,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 20,
+        ]);
+
+        $tiered30 = Price::factory()->create([
+            'price' => 70,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 30,
+        ]);
+
+        $pricing = $manager->qty(1)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($base->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(5)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($base->id, $pricing->matched->id);
+
         $pricing = $manager->qty(10)->for($variant);
 
-        $this->assertInstanceOf(PricingResponse::class, $pricing);
-        $this->assertCount(1, $pricing->tiered);
         $this->assertEquals($base->id, $pricing->base->id);
-        $this->assertEquals($tiered->id, $pricing->matched->id);
+        $this->assertEquals($tiered10->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(15)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($tiered10->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(20)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($tiered20->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(25)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($tiered20->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(30)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($tiered30->id, $pricing->matched->id);
+
+        $pricing = $manager->qty(100)->for($variant);
+
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($tiered30->id, $pricing->matched->id);
     }
 
     /**  @test */
@@ -215,48 +261,5 @@ class PricingManagerTest extends TestCase
         $this->assertInstanceOf(PricingResponse::class, $pricing);
 
         $this->assertEquals($price->id, $pricing->matched->id);
-    }
-
-    /** @test */
-    public function can_get_price_matched_with_tiers()
-    {
-        $manager = new PricingManager;
-
-        $currency = Currency::factory()->create([
-            'default' => true,
-            'exchange_rate' => 1,
-        ]);
-
-        $product = Product::factory()->create([
-            'status' => 'published',
-            'brand'  => 'BAR',
-        ]);
-
-        $variant = ProductVariant::factory()->create([
-            'product_id' => $product->id,
-        ]);
-
-
-        Price::factory()->create([
-            'price' => 100,
-            'priceable_type' => ProductVariant::class,
-            'priceable_id'   => $variant->id,
-            'currency_id'    => $currency->id,
-            'tier'           => 1,
-        ]);
-
-        $tieredPrice = Price::factory()->create([
-            'price' => 50,
-            'priceable_type' => ProductVariant::class,
-            'priceable_id'   => $variant->id,
-            'currency_id'    => $currency->id,
-            'tier'           => 10,
-        ]);
-
-        $pricing = $manager->qty(10)->for($variant);
-
-        $this->assertInstanceOf(PricingResponse::class, $pricing);
-
-        $this->assertEquals($tieredPrice->id, $pricing->matched->id);
     }
 }

--- a/packages/core/tests/Unit/Managers/PricingManagerTest.php
+++ b/packages/core/tests/Unit/Managers/PricingManagerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Managers;
+
+use GetCandy\Base\DataTransferObjects\PricingResponse;
+use GetCandy\Managers\PricingManager;
+use GetCandy\Models\Currency;
+use GetCandy\Models\Price;
+use GetCandy\Models\Product;
+use GetCandy\Models\ProductVariant;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group getcandy.pricing-manager
+ */
+class PricingManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_initialise_the_manager()
+    {
+        $this->assertInstanceOf(
+            PricingManager::class,
+            new PricingManager
+        );
+    }
+
+    /** @test */
+    public function can_get_purchasable_price_with_defaults()
+    {
+        $manager = new PricingManager;
+
+        $currency = Currency::factory()->create([
+            'default' => true,
+            'exchange_rate' => 1,
+        ]);
+
+        $product = Product::factory()->create([
+            'status' => 'published',
+            'brand'  => 'BAR',
+        ]);
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+
+        $price = Price::factory()->create([
+            'price' => 100,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 1,
+        ]);
+
+        $pricing = $manager->for($variant);
+
+        $this->assertInstanceOf(PricingResponse::class, $pricing);
+
+        $this->assertEquals($price->id, $pricing->matched->id);
+    }
+
+    /** @test */
+    public function can_get_price_matched_with_tiers()
+    {
+        $manager = new PricingManager;
+
+        $currency = Currency::factory()->create([
+            'default' => true,
+            'exchange_rate' => 1,
+        ]);
+
+        $product = Product::factory()->create([
+            'status' => 'published',
+            'brand'  => 'BAR',
+        ]);
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+
+        $price = Price::factory()->create([
+            'price' => 100,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 1,
+        ]);
+
+        $pricing = $manager->for($variant);
+
+        $this->assertInstanceOf(PricingResponse::class, $pricing);
+
+        $this->assertEquals($price->id, $pricing->matched->id);
+    }
+}

--- a/packages/core/tests/Unit/Managers/PricingManagerTest.php
+++ b/packages/core/tests/Unit/Managers/PricingManagerTest.php
@@ -26,17 +26,17 @@ class PricingManagerTest extends TestCase
     {
         $this->assertInstanceOf(
             PricingManager::class,
-            new PricingManager
+            new PricingManager()
         );
     }
 
     /** @test */
     public function can_set_up_available_guest_pricing()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $currency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
@@ -50,7 +50,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $base = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -58,7 +58,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         Price::factory()->create([
-            'price' => 50,
+            'price'          => 50,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -66,12 +66,12 @@ class PricingManagerTest extends TestCase
         ]);
 
         Price::factory()->create([
-            'price' => 50,
-            'priceable_type' => ProductVariant::class,
-            'priceable_id'   => $variant->id,
-            'currency_id'    => $currency->id,
-            'tier'           => 1,
-            'customer_group_id' => CustomerGroup::factory()
+            'price'             => 50,
+            'priceable_type'    => ProductVariant::class,
+            'priceable_id'      => $variant->id,
+            'currency_id'       => $currency->id,
+            'tier'              => 1,
+            'customer_group_id' => CustomerGroup::factory(),
         ]);
 
         $pricing = $manager->for($variant);
@@ -86,10 +86,10 @@ class PricingManagerTest extends TestCase
     /** @test */
     public function can_get_purchasable_price_with_defaults()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $currency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
@@ -102,9 +102,8 @@ class PricingManagerTest extends TestCase
             'product_id' => $product->id,
         ]);
 
-
         $price = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -121,12 +120,12 @@ class PricingManagerTest extends TestCase
     /**  @test */
     public function can_fetch_customer_group_price()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $customerGroups = CustomerGroup::factory(5)->create();
 
         $currency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
@@ -140,7 +139,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $base = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -148,11 +147,11 @@ class PricingManagerTest extends TestCase
         ]);
 
         $customerGroupPrice = Price::factory()->create([
-            'price' => 150,
-            'priceable_type' => ProductVariant::class,
-            'priceable_id'   => $variant->id,
-            'currency_id'    => $currency->id,
-            'tier'           => 1,
+            'price'             => 150,
+            'priceable_type'    => ProductVariant::class,
+            'priceable_id'      => $variant->id,
+            'currency_id'       => $currency->id,
+            'tier'              => 1,
             'customer_group_id' => $customerGroups->first()->id,
         ]);
 
@@ -176,10 +175,10 @@ class PricingManagerTest extends TestCase
     /** @test */
     public function can_fetch_tiered_price()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $currency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
@@ -193,7 +192,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $base = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -201,7 +200,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $tiered10 = Price::factory()->create([
-            'price' => 90,
+            'price'          => 90,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -209,7 +208,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $tiered20 = Price::factory()->create([
-            'price' => 80,
+            'price'          => 80,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -217,7 +216,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $tiered30 = Price::factory()->create([
-            'price' => 70,
+            'price'          => 70,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $currency->id,
@@ -268,15 +267,15 @@ class PricingManagerTest extends TestCase
     /** @test */
     public function can_match_based_on_currency()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $defaultCurrency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
         $secondCurrency = Currency::factory()->create([
-            'default' => false,
+            'default'       => false,
             'exchange_rate' => 1.2,
         ]);
 
@@ -290,7 +289,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $base = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $defaultCurrency->id,
@@ -298,7 +297,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $additional = Price::factory()->create([
-            'price' => 120,
+            'price'          => 120,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $secondCurrency->id,
@@ -319,7 +318,7 @@ class PricingManagerTest extends TestCase
     /** @test  */
     public function can_fetch_correct_price_for_user()
     {
-        $manager = new PricingManager;
+        $manager = new PricingManager();
 
         $user = User::factory()->create();
 
@@ -328,7 +327,7 @@ class PricingManagerTest extends TestCase
         $group = CustomerGroup::factory()->create();
 
         $defaultCurrency = Currency::factory()->create([
-            'default' => true,
+            'default'       => true,
             'exchange_rate' => 1,
         ]);
 
@@ -342,7 +341,7 @@ class PricingManagerTest extends TestCase
         ]);
 
         $base = Price::factory()->create([
-            'price' => 100,
+            'price'          => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
             'currency_id'    => $defaultCurrency->id,
@@ -350,11 +349,11 @@ class PricingManagerTest extends TestCase
         ]);
 
         $groupPrice = Price::factory()->create([
-            'price' => 100,
-            'priceable_type' => ProductVariant::class,
-            'priceable_id'   => $variant->id,
-            'currency_id'    => $defaultCurrency->id,
-            'tier'           => 1,
+            'price'             => 100,
+            'priceable_type'    => ProductVariant::class,
+            'priceable_id'      => $variant->id,
+            'currency_id'       => $defaultCurrency->id,
+            'tier'              => 1,
             'customer_group_id' => $group->id,
         ]);
 

--- a/packages/core/tests/Unit/Managers/PricingManagerTest.php
+++ b/packages/core/tests/Unit/Managers/PricingManagerTest.php
@@ -5,6 +5,7 @@ namespace GetCandy\Tests\Unit\Managers;
 use GetCandy\Base\DataTransferObjects\PricingResponse;
 use GetCandy\Managers\PricingManager;
 use GetCandy\Models\Currency;
+use GetCandy\Models\CustomerGroup;
 use GetCandy\Models\Price;
 use GetCandy\Models\Product;
 use GetCandy\Models\ProductVariant;
@@ -25,6 +26,106 @@ class PricingManagerTest extends TestCase
             PricingManager::class,
             new PricingManager
         );
+    }
+
+    /** @test */
+    public function can_set_up_available_guest_pricing()
+    {
+        $manager = new PricingManager;
+
+        $currency = Currency::factory()->create([
+            'default' => true,
+            'exchange_rate' => 1,
+        ]);
+
+        $product = Product::factory()->create([
+            'status' => 'published',
+            'brand'  => 'BAR',
+        ]);
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+        $base = Price::factory()->create([
+            'price' => 100,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 1,
+        ]);
+
+        Price::factory()->create([
+            'price' => 50,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 10,
+        ]);
+
+        Price::factory()->create([
+            'price' => 50,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 1,
+            'customer_group_id' => CustomerGroup::factory()
+        ]);
+
+        $pricing = $manager->for($variant);
+
+        $this->assertInstanceOf(PricingResponse::class, $pricing);
+        $this->assertCount(0, $pricing->customerGroupPrices);
+        $this->assertCount(1, $pricing->tiered);
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($base->id, $pricing->matched->id);
+    }
+
+    /**
+     * @test
+     * @group thisone
+     * */
+    public function can_fetch_tiered_price()
+    {
+        $manager = new PricingManager;
+
+        $currency = Currency::factory()->create([
+            'default' => true,
+            'exchange_rate' => 1,
+        ]);
+
+        $product = Product::factory()->create([
+            'status' => 'published',
+            'brand'  => 'BAR',
+        ]);
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+        $base = Price::factory()->create([
+            'price' => 100,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 1,
+        ]);
+
+        $tiered = Price::factory()->create([
+            'price' => 50,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 10,
+        ]);
+
+
+        $pricing = $manager->qty(10)->for($variant);
+
+        $this->assertInstanceOf(PricingResponse::class, $pricing);
+        $this->assertCount(1, $pricing->tiered);
+        $this->assertEquals($base->id, $pricing->base->id);
+        $this->assertEquals($$tiered->id, $pricing->matched->id);
     }
 
     /** @test */
@@ -82,7 +183,7 @@ class PricingManagerTest extends TestCase
         ]);
 
 
-        $price = Price::factory()->create([
+        Price::factory()->create([
             'price' => 100,
             'priceable_type' => ProductVariant::class,
             'priceable_id'   => $variant->id,
@@ -90,10 +191,18 @@ class PricingManagerTest extends TestCase
             'tier'           => 1,
         ]);
 
-        $pricing = $manager->for($variant);
+        $tieredPrice = Price::factory()->create([
+            'price' => 50,
+            'priceable_type' => ProductVariant::class,
+            'priceable_id'   => $variant->id,
+            'currency_id'    => $currency->id,
+            'tier'           => 10,
+        ]);
+
+        $pricing = $manager->qty(10)->for($variant);
 
         $this->assertInstanceOf(PricingResponse::class, $pricing);
 
-        $this->assertEquals($price->id, $pricing->matched->id);
+        $this->assertEquals($tieredPrice->id, $pricing->matched->id);
     }
 }

--- a/packages/core/tests/Unit/Models/ProductVariantTest.php
+++ b/packages/core/tests/Unit/Models/ProductVariantTest.php
@@ -45,7 +45,7 @@ class ProductVariantTest extends TestCase
             'product_id' => $product->id,
         ]);
         $currency = Currency::factory()->create([
-            'default' => true,
+            'default'        => true,
             'decimal_places' => 2,
         ]);
 

--- a/packages/core/tests/Unit/Models/ProductVariantTest.php
+++ b/packages/core/tests/Unit/Models/ProductVariantTest.php
@@ -3,6 +3,7 @@
 namespace GetCandy\Tests\Unit\Models;
 
 use GetCandy\Exceptions\MissingCurrencyPriceException;
+use GetCandy\Facades\Pricing;
 use GetCandy\Models\Currency;
 use GetCandy\Models\CustomerGroup;
 use GetCandy\Models\Product;
@@ -44,6 +45,7 @@ class ProductVariantTest extends TestCase
             'product_id' => $product->id,
         ]);
         $currency = Currency::factory()->create([
+            'default' => true,
             'decimal_places' => 2,
         ]);
 
@@ -90,11 +92,11 @@ class ProductVariantTest extends TestCase
 
         $variant = $variant->load('prices');
 
-        $this->assertEquals(100, $variant->getPrice(1, $currency));
-        $this->assertEquals(60, $variant->getPrice(5, $currency));
-        $this->assertEquals(30, $variant->getPrice(5, $currency, collect([$groupB])));
-        $this->assertEquals(80, $variant->getPrice(1, $currency, collect([$groupB])));
-        $this->assertEquals(90, $variant->getPrice(1, $currency, collect([$groupA])));
+        $this->assertEquals(Pricing::for($variant)->matched->price->value, 100);
+        $this->assertEquals(Pricing::qty(5)->for($variant)->matched->price->value, 60);
+        $this->assertEquals(Pricing::qty(5)->customerGroup($groupB)->for($variant)->matched->price->value, 30);
+        $this->assertEquals(Pricing::customerGroup($groupB)->for($variant)->matched->price->value, 80);
+        $this->assertEquals(Pricing::customerGroup($groupA)->for($variant)->matched->price->value, 90);
     }
 
     /** @test */
@@ -135,10 +137,10 @@ class ProductVariantTest extends TestCase
 
         $variant = $variant->load('prices');
 
-        $this->assertEquals(100, $variant->getPrice(1, $currencyA));
-        $this->assertEquals(200, $variant->getPrice(1, $currencyB));
+        $this->assertEquals(Pricing::currency($currencyA)->for($variant)->matched->price->value, 100);
+        $this->assertEquals(Pricing::currency($currencyB)->for($variant)->matched->price->value, 200);
 
         $this->expectException(MissingCurrencyPriceException::class);
-        $variant->getPrice(1, $currencyC);
+        $this->assertEquals(Pricing::currency($currencyC)->for($variant)->matched->price->value, 200);
     }
 }


### PR DESCRIPTION
This PR Looks to add an easy way for developers to get the pricing for a purchasable item.

The idea for this is that pricing is a fairly complex but crucial part of any online store. So we need to provide a way for developers to be able to consistently get the correct price for a purchasable item, the `PricingManager` looks to solve this.

Info on how it works can be found in the updated docs [on this file].(https://github.com/getcandy/getcandy/compare/release/2.0-beta8...feature/pricing-manager#diff-1569c18ce5bd15f8ee99b5c69828d56f4d9cd41cdc6b31b6e8fc88555cae485e)

You can use it via either the facade or by using DI

```php
// Using the facade
GetCandy\Facades\Pricing::for($variant);

// Using DI
public function __construct(GetCandy\Base\PricingManagerInterface $pricingManager)
{
    $pricingManager->for($this->variant);
}
```