### PR TITLE
Fix tests when running as a fresh project

### DIFF
--- a/packages/core/tests/Stubs/User.php
+++ b/packages/core/tests/Stubs/User.php
@@ -2,25 +2,18 @@
 
 namespace GetCandy\Tests\Stubs;
 
-use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Foundation\Auth\User as Authenticatable;
+use GetCandy\Base\Traits\GetCandyUser;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
-class User extends Authenticatable
+class User extends Model
 {
     use HasFactory;
     use Notifiable;
+    use GetCandyUser;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
-    protected $fillable = [
-        'name',
-        'email',
-        'password',
-    ];
+    protected $guarded = [];
 
     /**
      * The attributes that should be hidden for arrays.

--- a/packages/core/tests/Stubs/User.php
+++ b/packages/core/tests/Stubs/User.php
@@ -3,11 +3,11 @@
 namespace GetCandy\Tests\Stubs;
 
 use GetCandy\Base\Traits\GetCandyUser;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Notifications\Notifiable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
 
-class User extends Model
+class User extends Authenticatable
 {
     use HasFactory;
     use Notifiable;

--- a/packages/core/tests/Stubs/User.php
+++ b/packages/core/tests/Stubs/User.php
@@ -37,7 +37,7 @@ class User extends Model
     /**
      * Return a new factory instance for the model.
      *
-     * @return \GetCandy\Database\Factories\CustomerFactory
+     * @return \GetCandy\Database\Factories\UserFactory
      */
     protected static function newFactory(): UserFactory
     {

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -168,13 +168,36 @@ class OrderTest extends TestCase
     /** @test */
     public function can_have_user_and_customer_associated()
     {
-        $user = User::create([
-            'name'              => 'Test User',
-            'email'             => 'test@domain.com',
-            'email_verified_at' => now(),
-            'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-            'remember_token'    => \Illuminate\Support\Str::random(10),
-        ]);
+        $userModel = config('auth.providers.users.model') ?? null;
+
+        if (!$userModel) {
+            $this->markTestSkipped('User model not configured');
+        }
+
+        $user = null;
+
+        try {
+            $user = $userModel::create([
+                'name'              => 'Test User',
+                'email'             => 'test@domain.com',
+                'email_verified_at' => now(),
+                'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+                'remember_token'    => \Illuminate\Support\Str::random(10),
+            ]);
+        } catch (\Illuminate\Database\Eloquent\MassAssignmentException $e) {
+            // can't mass assign...
+            $user = new $userModel();
+            $user->name = 'Test User';
+            $user->email = 'test@domain.com';
+            $user->email_verified_at = now();
+            $user->password = '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'; // password
+            $user->remember_token = \Illuminate\Support\Str::random(10);
+            $user->save();
+        }
+
+        if (!\method_exists($user, 'customers')) {
+            $this->markTestSkipped('User model does not have a customers relationship');
+        }
 
         $customer = $user->customers()->create(
             Customer::factory()->make()->toArray()

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -3,13 +3,14 @@
 namespace GetCandy\Tests\Unit\Models;
 
 use DateTime;
+use GetCandy\Models\Order;
+use GetCandy\Tests\TestCase;
 use GetCandy\Models\Currency;
 use GetCandy\Models\Customer;
-use GetCandy\Models\Order;
 use GetCandy\Models\OrderLine;
-use GetCandy\Models\ProductVariant;
+use GetCandy\Tests\Stubs\User;
 use GetCandy\Models\Transaction;
-use GetCandy\Tests\TestCase;
+use GetCandy\Models\ProductVariant;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 /**
@@ -167,36 +168,13 @@ class OrderTest extends TestCase
     /** @test */
     public function can_have_user_and_customer_associated()
     {
-        $userModel = config('auth.providers.users.model') ?? null;
-
-        if (!$userModel) {
-            $this->markTestSkipped('User model not configured');
-        }
-
-        $user = null;
-
-        try {
-            $user = $userModel::create([
-                'name'              => 'Test User',
-                'email'             => 'test@domain.com',
-                'email_verified_at' => now(),
-                'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
-                'remember_token'    => \Illuminate\Support\Str::random(10),
-            ]);
-        } catch (\Illuminate\Database\Eloquent\MassAssignmentException $e) {
-            // can't mass assign...
-            $user = new $userModel();
-            $user->name = 'Test User';
-            $user->email = 'test@domain.com';
-            $user->email_verified_at = now();
-            $user->password = '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi'; // password
-            $user->remember_token = \Illuminate\Support\Str::random(10);
-            $user->save();
-        }
-
-        if (!\method_exists($user, 'customers')) {
-            $this->markTestSkipped('User model does not have a customers relationship');
-        }
+        $user = User::create([
+            'name'              => 'Test User',
+            'email'             => 'test@domain.com',
+            'email_verified_at' => now(),
+            'password'          => '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', // password
+            'remember_token'    => \Illuminate\Support\Str::random(10),
+        ]);
 
         $customer = $user->customers()->create(
             Customer::factory()->make()->toArray()

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -3,7 +3,6 @@
 namespace GetCandy\Tests\Unit\Models;
 
 use DateTime;
-use GetCandy\Hub\Tests\Stubs\User;
 use GetCandy\Models\Currency;
 use GetCandy\Models\Customer;
 use GetCandy\Models\Order;


### PR DESCRIPTION
This PR fixes the `can_have_user_and_customer_associated` test which originally was failing to this error: 

`Class "GetCandy\Hub\Tests\Stubs\User" not found`