### PR TITLE
Hotfix - Stop charts duplicating on the dashboard

### DIFF
--- a/packages/admin/resources/views/livewire/components/reporting/apex-charts.blade.php
+++ b/packages/admin/resources/views/livewire/components/reporting/apex-charts.blade.php
@@ -1,15 +1,14 @@
 <div
     style="width: 100%; height: 100%;"
     x-data="{
-    init() {
-        var el = document.querySelector('#' + this.$wire.get('key'));
-        var options = this.$wire.get('options');
+        init() {
+            var el = document.querySelector('#' + this.$wire.get('key'));
+            var options = this.$wire.get('options');
 
-        var chart = new ApexCharts(el, options);
-        chart.render();
-    }
-}"
-    x-init="init()"
+            var chart = new ApexCharts(el, options);
+            chart.render();
+        }
+    }"
 >
     <div id="{{ $this->key }}"></div>
 </div>


### PR DESCRIPTION
Fixes #100 

The upgrade with Alpine means that `init` gets called automatically so we're in fact calling it twice at the moment, resulting in a weird graph duplication visual.