### PR TITLE
feat[Core]: Add base_price accessor to Product model

### DIFF
--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -118,6 +118,17 @@ class Product extends BaseModel implements SpatieHasMedia
     }
 
     /**
+     *
+     * @return int
+     */
+    public function getBasePriceAttribute()
+    {
+        return $this->variants->first()
+            ->basePrices->first(fn($price) => $price->currency->default)
+            ->price->value;
+    }
+
+    /**
      * Associate a product to another with a type.
      *
      * @param mixed  $product

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -118,13 +118,14 @@ class Product extends BaseModel implements SpatieHasMedia
     }
 
     /**
+     * Returns the base price of the product.
      *
      * @return int
      */
     public function getBasePriceAttribute()
     {
         return $this->variants->first()
-            ->basePrices->first(fn($price) => $price->currency->default)
+            ->basePrices->first(fn ($price) => $price->currency->default)
             ->price->value;
     }
 

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -3,10 +3,12 @@
 namespace GetCandy\Tests\Unit\Models;
 
 use GetCandy\Models\Channel;
+use GetCandy\Models\Currency;
 use GetCandy\Models\CustomerGroup;
 use GetCandy\Models\Product;
 use GetCandy\Models\ProductAssociation;
 use GetCandy\Models\ProductType;
+use GetCandy\Models\ProductVariant;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -436,5 +438,28 @@ class ProductTest extends TestCase
 
         $this->assertCount(1, $parent->refresh()->associations);
         $this->assertEquals('up-sell', $parent->refresh()->associations->first()->type);
+    }
+
+    /** @test */
+    public function product_has_base_price_attribute()
+    {
+        $product = Product::factory()->create();
+
+        $variant = ProductVariant::factory()->create([
+            'product_id' => $product->id,
+        ]);
+
+        $currency = Currency::factory()->create([
+            'name' => 'Us Dollar',
+            'code' => 'USD',
+            'exchange_rate' => 1.0,
+        ]);
+
+        $variant->prices()->create([
+            'price'       => 199,
+            'currency_id' => $currency->id,
+        ]);
+
+        $this->assertEquals(199, $product->base_price);
     }
 }

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -450,8 +450,8 @@ class ProductTest extends TestCase
         ]);
 
         $currency = Currency::factory()->create([
-            'name' => 'Us Dollar',
-            'code' => 'USD',
+            'name'          => 'Us Dollar',
+            'code'          => 'USD',
             'exchange_rate' => 1.0,
         ]);
 


### PR DESCRIPTION
Usage example: `$product->base_price->formatted`

```blade
<product-card name="{{$product->translateAttribute('name')}}"
                        price="{{$product->base_price->formatted}}"
                        image=""
></product-card>
```

The way it currently is used in the hub looks something like this and this PR can make this approach cleaner:
```blade
@php
    $price = $variant->basePrices->first(fn($price) => $price->currency->default);
@endphp
{{ $price->price->formatted }}
```