### PR TITLE
Fix LoginForm redirect intended & wire:model

### DIFF
--- a/packages/admin/resources/views/livewire/components/login-form.blade.php
+++ b/packages/admin/resources/views/livewire/components/login-form.blade.php
@@ -7,7 +7,7 @@
           Email address
         </label>
         <div class="mt-1">
-          <input id="email" wire:model="email" name="email" type="email" autocomplete="email" required class="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+          <input id="email" wire:model.defer="email" name="email" type="email" autocomplete="email" required class="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
         </div>
         @error('email') <span class="error">{{ $message }}</span> @enderror
       </div>
@@ -16,13 +16,13 @@
           Password
         </label>
         <div class="mt-1">
-          <input id="password" wire:model="password" name="password" type="password" autocomplete="current-password" required class="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
+          <input id="password" wire:model.defer="password" name="password" type="password" autocomplete="current-password" required class="block w-full px-3 py-2 placeholder-gray-400 border border-gray-300 rounded-md shadow-sm appearance-none focus:outline-none focus:ring-indigo-500 focus:border-indigo-500 sm:text-sm">
         </div>
       </div>
 
       <div class="flex items-center justify-between">
         <div class="flex items-center">
-          <input wire:model="remember" id="remember-me" name="remember-me" type="checkbox" class="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500">
+          <input wire:model.defer="remember" id="remember-me" name="remember-me" type="checkbox" class="w-4 h-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500">
           <label for="remember-me" class="block ml-2 text-sm text-gray-900">
             Remember me
           </label>

--- a/packages/admin/src/Http/Livewire/Components/Authentication/LoginForm.php
+++ b/packages/admin/src/Http/Livewire/Components/Authentication/LoginForm.php
@@ -57,7 +57,7 @@ class LoginForm extends Component
         ], $this->remember);
 
         if ($authCheck) {
-            $this->redirectRoute('hub.index');
+            return redirect()->intended(route('hub.index'));
         }
 
         session()->flash('error', 'The provided credentials do not match our records.');


### PR DESCRIPTION
This PR makes redirect to previously intended location (useful when your session expired), fixes redirect error flash message and wire:model unnecessary requests