### PR TITLE
Enhancement - Tweaks to CartManager and how addresses are handled

### DIFF
--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -308,8 +308,6 @@ class CartManager
      */
     public function setShippingAddress(array|Addressable $address)
     {
-        $this->cart->shippingAddress?->delete();
-
         $this->addAddress($address, 'shipping');
 
         $this->cart->load('shippingAddress');
@@ -326,8 +324,6 @@ class CartManager
      */
     public function setBillingAddress(array|Addressable $address)
     {
-        $this->cart->billingAddress?->delete();
-
         $this->addAddress($address, 'billing');
 
         $this->cart->load('billingAddress');
@@ -417,9 +413,9 @@ class CartManager
     private function addAddress(array|Addressable $address, $type)
     {
         if ($address instanceof Addressable) {
-            $address = $address->only(
-                (new CartAddress())->getFillable()
-            );
+            $address->type = $type;
+            $this->cart->addresses()->save($address);
+            return;
         }
         $address['type'] = $type;
         $this->cart->addresses()->create($address);

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -414,7 +414,14 @@ class CartManager
     {
         if ($address instanceof Addressable) {
             $address->type = $type;
-            $this->cart->addresses()->save($address);
+            if ($address->id) {
+                $this->cart->addresses()->save($address);
+            } else {
+                $this->cart->addresses()->create(
+                    $address->toArray()
+                );
+            }
+
             return;
         }
         $address['type'] = $type;

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -487,25 +487,25 @@ class CartManagerTest extends TestCase
             'currency_id' => $currency->id,
         ]);
 
-        $shipping = new CartAddress;
+        $shipping = new CartAddress();
         $shipping->postcode = 'SHI P12';
 
-        $billing = new CartAddress;
+        $billing = new CartAddress();
         $billing->postcode = 'BIL L12';
 
         $cart->getManager()->setShippingAddress($shipping);
         $cart->getManager()->setBillingAddress($billing);
 
-        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+        $this->assertDatabaseHas((new CartAddress())->getTable(), [
             'postcode' => $shipping->postcode,
-            'cart_id' => $cart->id,
-            'type' => 'shipping',
+            'cart_id'  => $cart->id,
+            'type'     => 'shipping',
         ]);
 
-        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+        $this->assertDatabaseHas((new CartAddress())->getTable(), [
             'postcode' => $billing->postcode,
-            'cart_id' => $cart->id,
-            'type' => 'billing',
+            'cart_id'  => $cart->id,
+            'type'     => 'billing',
         ]);
     }
 
@@ -518,10 +518,10 @@ class CartManagerTest extends TestCase
             'currency_id' => $currency->id,
         ]);
 
-        $shipping = new CartAddress;
+        $shipping = new CartAddress();
         $shipping->postcode = 'SHI P12';
 
-        $billing = new CartAddress;
+        $billing = new CartAddress();
         $billing->postcode = 'BIL L12';
 
         $cart->getManager()->setShippingAddress($shipping);
@@ -534,10 +534,10 @@ class CartManagerTest extends TestCase
 
         $cart->getManager()->setShippingAddress($shipping);
 
-        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+        $this->assertDatabaseHas((new CartAddress())->getTable(), [
             'postcode' => $shipping->postcode,
-            'cart_id' => $cart->id,
-            'type' => 'shipping',
+            'cart_id'  => $cart->id,
+            'type'     => 'shipping',
         ]);
 
         $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());
@@ -553,7 +553,7 @@ class CartManagerTest extends TestCase
             'currency_id' => $currency->id,
         ]);
 
-        $shipping = new CartAddress;
+        $shipping = new CartAddress();
         $shipping->postcode = 'SHI P12';
 
         $cart->getManager()->setShippingAddress($shipping);
@@ -568,10 +568,10 @@ class CartManagerTest extends TestCase
 
         $cart->getManager()->setBillingAddress($shipping);
 
-        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+        $this->assertDatabaseHas((new CartAddress())->getTable(), [
             'postcode' => $shipping->postcode,
-            'cart_id' => $cart->id,
-            'type' => 'billing',
+            'cart_id'  => $cart->id,
+            'type'     => 'billing',
         ]);
 
         $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -10,6 +10,7 @@ use GetCandy\Exceptions\InvalidCartLineQuantityException;
 use GetCandy\Exceptions\MaximumCartLineQuantityException;
 use GetCandy\Managers\CartManager;
 use GetCandy\Models\Cart;
+use GetCandy\Models\CartAddress;
 use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Currency;
@@ -475,5 +476,105 @@ class CartManagerTest extends TestCase
         $cart->getManager()->removeLine($anotherLine->id);
 
         $this->assertCount(2, $cart->refresh()->lines);
+    }
+
+    /** @test */
+    public function can_add_addresses_from_addressable_objects()
+    {
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $shipping = new CartAddress;
+        $shipping->postcode = 'SHI P12';
+
+        $billing = new CartAddress;
+        $billing->postcode = 'BIL L12';
+
+        $cart->getManager()->setShippingAddress($shipping);
+        $cart->getManager()->setBillingAddress($billing);
+
+        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+            'postcode' => $shipping->postcode,
+            'cart_id' => $cart->id,
+            'type' => 'shipping',
+        ]);
+
+        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+            'postcode' => $billing->postcode,
+            'cart_id' => $cart->id,
+            'type' => 'billing',
+        ]);
+    }
+
+    /** @test */
+    public function can_update_shipping_address()
+    {
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $shipping = new CartAddress;
+        $shipping->postcode = 'SHI P12';
+
+        $billing = new CartAddress;
+        $billing->postcode = 'BIL L12';
+
+        $cart->getManager()->setShippingAddress($shipping);
+        $cart->getManager()->setBillingAddress($billing);
+
+        $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());
+        $this->assertEquals(1, $cart->addresses()->whereType('billing')->count());
+
+        $shipping->postcode = 'TES T34';
+
+        $cart->getManager()->setShippingAddress($shipping);
+
+        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+            'postcode' => $shipping->postcode,
+            'cart_id' => $cart->id,
+            'type' => 'shipping',
+        ]);
+
+        $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());
+        $this->assertEquals(1, $cart->addresses()->whereType('billing')->count());
+    }
+
+    /** @test */
+    public function can_handle_different_address_type_reuse()
+    {
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $shipping = new CartAddress;
+        $shipping->postcode = 'SHI P12';
+
+        $cart->getManager()->setShippingAddress($shipping);
+
+        $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());
+        $this->assertEquals(0, $cart->addresses()->whereType('billing')->count());
+
+        $shipping = $cart->addresses()->whereType('shipping')->first();
+
+        $this->assertNotNull($shipping->id);
+        $this->assertEquals('shipping', $shipping->type);
+
+        $cart->getManager()->setBillingAddress($shipping);
+
+        $this->assertDatabaseHas((new CartAddress)->getTable(), [
+            'postcode' => $shipping->postcode,
+            'cart_id' => $cart->id,
+            'type' => 'billing',
+        ]);
+
+        $this->assertEquals(1, $cart->addresses()->whereType('shipping')->count());
+        $this->assertEquals(1, $cart->addresses()->whereType('billing')->count());
     }
 }


### PR DESCRIPTION
Originally we was removing the address before adding a new one. Which is a pain as it means ID's increment for no reason and Livewire doesn't like it when hydrating. So this change keeps the original records in tact in the database, just updating them where required.