### PR TITLE
Prevent pricing saving twice

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -291,7 +291,7 @@ abstract class AbstractProduct extends Component
                 GenerateVariants::dispatch($this->product, $this->optionValues);
             }
 
-            if (! $generateVariants && $this->product->variants->count() <= 1) {
+            if (! $generateVariants && $this->product->variants->count() <= 1 && !$isNew) {
                 // Only save pricing if we're not generating new variants.
                 $this->savePricing();
             }

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -291,7 +291,7 @@ abstract class AbstractProduct extends Component
                 GenerateVariants::dispatch($this->product, $this->optionValues);
             }
 
-            if (! $generateVariants && $this->product->variants->count() <= 1 && !$isNew) {
+            if (! $generateVariants && $this->product->variants->count() <= 1 && ! $isNew) {
                 // Only save pricing if we're not generating new variants.
                 $this->savePricing();
             }

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -79,7 +79,7 @@ class ProductCreateTest extends TestCase
         ]);
 
         $this->assertDatabaseHas((new Price)->getTable(), [
-            'price' => "123400",
+            'price' => '123400',
         ]);
 
         $this->assertDatabaseCount((new Price)->getTable(), 1);

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace GetCandy\Hub\Tests\Unit\Http\Livewire\Components\Products;
+
+use GetCandy\Hub\Http\Livewire\Components\Products\ProductCreate;
+use GetCandy\Hub\Models\Staff;
+use GetCandy\Hub\Tests\TestCase;
+use GetCandy\Models\Currency;
+use GetCandy\Models\Language;
+use GetCandy\Models\Price;
+use GetCandy\Models\ProductType;
+use GetCandy\Models\ProductVariant;
+use GetCandy\Models\TaxClass;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+/**
+ * @group hub.products
+ */
+class ProductCreateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+
+        Language::factory()->create([
+            'default' => false,
+            'code'    => 'fr',
+        ]);
+
+        Currency::factory()->create([
+            'default'        => true,
+            'decimal_places' => 2,
+        ]);
+
+        TaxClass::factory()->create([
+            'default' => true,
+        ]);
+
+        ProductType::factory()->create();
+    }
+
+    /** @test  */
+    public function component_mounts_correctly()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class);
+    }
+
+    /** @test */
+    public function can_create_product()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $currency = Currency::getDefault();
+
+        LiveWire::actingAs($staff, 'staff')
+            ->test(ProductCreate::class)
+            ->set('variant.sku', '1234')
+            ->set("basePrices.{$currency->code}.price", 1234)
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertDatabaseHas((new ProductVariant)->getTable(), [
+            'sku' => '1234',
+        ]);
+
+        $this->assertDatabaseHas((new Price)->getTable(), [
+            'price' => "123400",
+        ]);
+
+        $this->assertDatabaseCount((new Price)->getTable(), 1);
+    }
+}


### PR DESCRIPTION
When creating a product, we need to save the pricing initially in case we're generating variants as well. However this was being called twice so this PR adds an additional check to prevent that.