### PR TITLE
Prevent duplicate cart lines

### DIFF
--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -167,7 +167,7 @@ class CartManager
         $existing = $this->cart->lines->first(function ($line) use ($purchasable, $meta) {
             return $line->purchasable_id == $purchasable->id &&
             $line->purchasable_type == get_class($purchasable) &&
-            json_encode($line->meta) == json_encode($meta);
+            json_encode($line->meta ?: []) == json_encode($meta ?: []);
         });
 
         if ($existing) {

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -164,7 +164,7 @@ class CartManager
         }
 
         // Do we already have this line?
-        $existing = $this->cart->lines->first(function ($line) use ($purchasable, $meta) {
+        $existing = $this->cart->load('lines')->lines->first(function ($line) use ($purchasable, $meta) {
             return $line->purchasable_id == $purchasable->id &&
             $line->purchasable_type == get_class($purchasable) &&
             json_encode($line->meta ?: []) == json_encode($meta ?: []);

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -323,7 +323,7 @@ class CartManagerTest extends TestCase
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasable->id,
             'quantity' => 1,
-            'meta' => "[]",
+            'meta' => '[]',
         ]);
 
         $this->assertDatabaseCount((new CartLine)->getTable(), 1);
@@ -333,7 +333,7 @@ class CartManagerTest extends TestCase
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasable->id,
             'quantity' => 2,
-            'meta' => "[]",
+            'meta' => '[]',
         ]);
 
         $cart->getManager()->add($purchasable, 1, []);
@@ -341,7 +341,7 @@ class CartManagerTest extends TestCase
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasable->id,
             'quantity' => 3,
-            'meta' => "[]",
+            'meta' => '[]',
         ]);
 
         $this->assertDatabaseCount((new CartLine)->getTable(), 1);
@@ -353,7 +353,7 @@ class CartManagerTest extends TestCase
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasable->id,
             'quantity' => 4,
-            'meta' => "[]",
+            'meta' => '[]',
         ]);
 
         $this->assertDatabaseCount((new CartLine)->getTable(), 1);
@@ -363,7 +363,7 @@ class CartManagerTest extends TestCase
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasable->id,
             'quantity' => 4,
-            'meta' => "[]",
+            'meta' => '[]',
         ]);
 
         $this->assertDatabaseHas((new CartLine)->getTable(), [

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -282,6 +282,100 @@ class CartManagerTest extends TestCase
     }
 
     /** @test */
+    public function can_update_cart_line_when_purchasable_exists()
+    {
+        $cart = Cart::factory()->create();
+
+        $purchasable = ProductVariant::factory()->create();
+
+        $this->assertCount(0, $cart->lines);
+
+        $cart->getManager()->add($purchasable, 1, null);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 1,
+            'meta' => null,
+        ]);
+
+        $this->assertCount(1, $cart->refresh()->lines);
+
+        $cart->getManager()->add($purchasable, 1, null);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 2,
+            'meta' => null,
+        ]);
+    }
+
+    /** @test */
+    public function can_update_cart_line_when_purchasable_exists_with_meta()
+    {
+        $cart = Cart::factory()->create();
+
+        $purchasable = ProductVariant::factory()->create();
+
+        $this->assertCount(0, $cart->lines);
+
+        $cart->getManager()->add($purchasable, 1, []);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 1,
+            'meta' => "[]",
+        ]);
+
+        $this->assertDatabaseCount((new CartLine)->getTable(), 1);
+
+        $cart->getManager()->add($purchasable, 1);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 2,
+            'meta' => "[]",
+        ]);
+
+        $cart->getManager()->add($purchasable, 1, []);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 3,
+            'meta' => "[]",
+        ]);
+
+        $this->assertDatabaseCount((new CartLine)->getTable(), 1);
+
+        $this->assertDatabaseCount((new CartLine)->getTable(), 1);
+
+        $cart->getManager()->add($purchasable, 1, null);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 4,
+            'meta' => "[]",
+        ]);
+
+        $this->assertDatabaseCount((new CartLine)->getTable(), 1);
+
+        $cart->getManager()->add($purchasable, 1, ['foo' => 'bar']);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 4,
+            'meta' => "[]",
+        ]);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasable->id,
+            'quantity' => 1,
+            'meta' => '{"foo":"bar"}',
+        ]);
+
+        $this->assertDatabaseCount((new CartLine)->getTable(), 2);
+    }
+
+    /** @test */
     public function can_add_same_purchasable_with_different_meta()
     {
         $cart = Cart::factory()->create();


### PR DESCRIPTION
This PR looks to tweak the cart line check when adding an item.

Currently if either one is null but not the other, it doesn't match and results in a duplicate cart line being added. This PR defaults both to an empty array `[]` when there is no value.