### PR TITLE
Add tax reference field to hub

### DIFF
--- a/packages/admin/resources/lang/en/inputs.php
+++ b/packages/admin/resources/lang/en/inputs.php
@@ -62,4 +62,6 @@ return [
     'validation_rules.label'                 => 'Validation Rules',
     'min.label'                              => 'Min.',
     'max.label'                              => 'Max.',
+    'tax_ref.label' => 'Tax Reference',
+    'tax_ref.instructions' => 'Add the third party tax reference, if required.'
 ];

--- a/packages/admin/resources/lang/en/inputs.php
+++ b/packages/admin/resources/lang/en/inputs.php
@@ -63,5 +63,5 @@ return [
     'min.label'                              => 'Min.',
     'max.label'                              => 'Max.',
     'tax_ref.label' => 'Tax Reference',
-    'tax_ref.instructions' => 'Add the third party tax reference, if required.'
+    'tax_ref.instructions' => 'Add the third party tax reference, if required.',
 ];

--- a/packages/admin/resources/views/partials/pricing.blade.php
+++ b/packages/admin/resources/views/partials/pricing.blade.php
@@ -30,6 +30,18 @@
         </div>
         <div>
           <x-hub::input.group
+            :label="__('adminhub::inputs.tax_ref.label')"
+            :instructions="__('adminhub::inputs.tax_ref.instructions')"
+            :errors="$errors->get('variant.tax_ref')"
+            for="unit_quantity"
+          >
+            <x-hub::input.text wire:model="variant.tax_ref" id="tax_ref" />
+          </x-hub::input.group>
+        </div>
+      </div>
+      <div class="space-y-4">
+        <div class="grid grid-cols-3 gap-4">
+          <x-hub::input.group
             :label="__('adminhub::inputs.unit_quantity.label')"
             :instructions="__('adminhub::inputs.unit_quantity.instructions')"
             :errors="$errors->get('variant.unit_quantity')"
@@ -37,10 +49,7 @@
           >
             <x-hub::input.text type="number" wire:model="variant.unit_quantity" id="unit_quantity" />
           </x-hub::input.group>
-        </div>
-      </div>
-      <div class="space-y-4">
-        <div class="grid grid-cols-2 gap-4">
+
           <x-hub::input.group
             :label="__('adminhub::inputs.base_price_excl_tax.label')"
             :instructions="__('adminhub::inputs.base_price_excl_tax.instructions')"

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -145,6 +145,7 @@ abstract class AbstractProduct extends Component
             'product.brand'           => 'nullable|string|max:255',
             'product.product_type_id' => 'required',
             'urls'                    => 'array',
+            'variant.tax_ref'         => 'nullable|string|max:255',
             'variant.sku'             => get_validation('products', 'sku', [
                 'alpha_dash',
                 'max:255',
@@ -183,6 +184,7 @@ abstract class AbstractProduct extends Component
                     'variant.volume_value'  => 'numeric|nullable',
                     'variant.volume_unit'   => 'string|nullable',
                     'variant.shippable'     => 'boolean|nullable',
+                    'variant.tax_ref'         => 'nullable|string|max:255',
                     'variant.unit_quantity' => 'required|numeric|min:1|max:10000000',
                 ]
             );

--- a/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/Variants/VariantShow.php
@@ -153,6 +153,7 @@ class VariantShow extends Component
             'variant.volume_unit'   => 'string|nullable',
             'variant.shippable'     => 'boolean|nullable',
             'variant.backorder'     => 'numeric|max:10000000',
+            'variant.tax_ref'         => 'nullable|string|max:255',
             'variant.purchasable'   => 'string|required',
             'variant.unit_quantity' => 'required|numeric|min:1|max:10000000',
             'variant.sku'           => get_validation('products', 'sku', [

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductCreateTest.php
@@ -70,12 +70,14 @@ class ProductCreateTest extends TestCase
         LiveWire::actingAs($staff, 'staff')
             ->test(ProductCreate::class)
             ->set('variant.sku', '1234')
+            ->set('variant.tax_ref', 'CUSTOMTAX')
             ->set("basePrices.{$currency->code}.price", 1234)
             ->call('save')
             ->assertHasNoErrors();
 
         $this->assertDatabaseHas((new ProductVariant)->getTable(), [
             'sku' => '1234',
+            'tax_ref' => 'CUSTOMTAX',
         ]);
 
         $this->assertDatabaseHas((new Price)->getTable(), [

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Products/ProductShowTest.php
@@ -181,14 +181,17 @@ class ProductShowTest extends TestCase
             ->assertSet('variant.ean', $variant->ean)
             ->assertSet('variant.gtin', $variant->gtin)
             ->assertSet('variant.mpn', $variant->mpn)
+            ->assertSet('vartian.tax_ref', $variant->tax_ref)
             ->set('variant.sku', 'FOOBAR')
             ->set('variant.ean', 'NEWEAN')
             ->set('variant.gtin', 'NEWGTIN')
             ->set('variant.mpn', 'NEWMPN')
+            ->set('variant.tax_ref', 'CUSTOMTAXREF')
             ->assertSet('variant.ean', 'NEWEAN')
             ->assertSet('variant.gtin', 'NEWGTIN')
             ->assertSet('variant.mpn', 'NEWMPN')
             ->assertSet('variant.sku', 'FOOBAR')
+            ->assertSet('variant.tax_ref', 'CUSTOMTAXREF')
             ->call('save')
             ->assertHasNoErrors([
                 'variant.sku',


### PR DESCRIPTION
This PR looks to add the missing `tax_ref` variant field to the hub so it's editable by users.