### PR TITLE
Bug fix: don't assume `id` is the user key

### DIFF
--- a/packages/core/src/Listeners/CartSessionAuthListener.php
+++ b/packages/core/src/Listeners/CartSessionAuthListener.php
@@ -39,7 +39,7 @@ class CartSessionAuthListener
 
         if (! $currentCart) {
             // Does this user have a cart?
-            $userCart = Cart::whereUserId($event->user->id)->latest()->first();
+            $userCart = Cart::whereUserId($event->user->getKey())->latest()->first();
 
             if ($userCart) {
                 CartSession::use($userCart);

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -272,14 +272,14 @@ class CartManager
     public function associate(User $user, $policy = 'merge')
     {
         if ($policy == 'merge') {
-            $userCart = Cart::whereUserId($user->id)->unMerged()->latest()->first();
+            $userCart = Cart::whereUserId($user->getKey())->unMerged()->latest()->first();
             if ($userCart) {
                 $this->cart = app(MergeCart::class)->execute($userCart, $this->cart);
             }
         }
 
         if ($policy == 'override') {
-            $userCart = Cart::whereUserId($user->id)->unMerged()->latest()->first();
+            $userCart = Cart::whereUserId($user->getKey())->unMerged()->latest()->first();
             if ($userCart && $userCart->id != $this->cart->id) {
                 $userCart->update([
                     'merged_id' => $userCart->id,
@@ -288,7 +288,7 @@ class CartManager
         }
 
         $this->cart->update([
-            'user_id' => $user->id,
+            'user_id' => $user->getKey(),
         ]);
 
         return $this->cart;

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -81,7 +81,7 @@ class CartTest extends TestCase
         $cart = Cart::create([
             'currency_id' => $currency->id,
             'channel_id'  => $channel->id,
-            'user_id'     => $user->id,
+            'user_id'     => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
@@ -102,7 +102,7 @@ class CartTest extends TestCase
         $cart = Cart::create([
             'currency_id' => $currency->id,
             'channel_id'  => $channel->id,
-            'user_id'     => $user->id,
+            'user_id'     => $user->getKey(),
         ]);
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());

--- a/packages/core/tests/Unit/Models/OrderTest.php
+++ b/packages/core/tests/Unit/Models/OrderTest.php
@@ -182,10 +182,10 @@ class OrderTest extends TestCase
 
         $order = Order::factory()->create([
             'customer_id' => $customer->id,
-            'user_id'     => $user->id,
+            'user_id'     => $user->getKey(),
         ]);
 
         $this->assertEquals($customer->id, $order->customer->id);
-        $this->assertEquals($user->id, $order->user->id);
+        $this->assertEquals($user->getKey(), $order->user->getKey());
     }
 }


### PR DESCRIPTION
Use getKey() instead