### PR TITLE
Add macro support to all models

### DIFF
--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -3,9 +3,14 @@
 namespace GetCandy\Base;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Traits\Macroable;
 
 abstract class BaseModel extends Model
 {
+    use Macroable {
+        __call as macroCall;
+    }
+
     /**
      * Create a new instance of the Model.
      *
@@ -16,5 +21,21 @@ abstract class BaseModel extends Model
         parent::__construct($attributes);
 
         $this->setTable(config('getcandy.database.table_prefix').$this->getTable());
+    }
+
+    /**
+     * Handle dynamic method calls into the model.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public function __call($method, $parameters)
+    {
+        if (static::hasMacro($method)) {
+            return $this->macroCall($method, $parameters);
+        }
+
+        return parent::__call($method, $parameters);
     }
 }

--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -38,4 +38,16 @@ abstract class BaseModel extends Model
 
         return parent::__call($method, $parameters);
     }
+
+    /**
+     * Handle dynamic static method calls into the model.
+     *
+     * @param  string  $method
+     * @param  array  $parameters
+     * @return mixed
+     */
+    public static function __callStatic($method, $parameters)
+    {
+        return parent::__callStatic($method, $parameters);
+    }
 }

--- a/packages/core/tests/Unit/Base/MacroableModelTest.php
+++ b/packages/core/tests/Unit/Base/MacroableModelTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Base;
+
+use GetCandy\Models\Product;
+use GetCandy\Tests\TestCase;
+
+/**
+ * @group reference
+ */
+class MacroableModelTest extends TestCase
+{
+    protected $model;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new Product();
+    }
+
+    /** @test */
+    public function can_register_a_new_macro()
+    {
+        $this->model::macro('newMethod', function () {
+            return 'newValue';
+        });
+
+        $this->assertEquals('newValue', $this->model->newMethod());
+        $this->assertEquals('newValue', $this->model::newMethod());
+    }
+
+    /** @test */
+    public function can_register_a_new_macro_and_be_invoked()
+    {
+        $this->model::macro('newMethod', new class()
+        {
+            public function __invoke()
+            {
+                return 'newValue';
+            }
+        });
+
+        $this->assertEquals('newValue', $this->model->newMethod());
+        $this->assertEquals('newValue', $this->model::newMethod());
+    }
+}


### PR DESCRIPTION
See #144 

Laravel already has a built in Macroable trait, used that instead of the **spatie/macroable**, as no extra dependencies are needed.