### PR TITLE
Add more tolerance to value stored on the TextField

### DIFF
--- a/packages/core/src/FieldTypes/Text.php
+++ b/packages/core/src/FieldTypes/Text.php
@@ -60,7 +60,7 @@ class Text implements FieldType, JsonSerializable
      */
     public function setValue($value)
     {
-        if ($value && (!is_string($value) && !is_numeric($value) && !is_bool($value))) {
+        if ($value && (! is_string($value) && ! is_numeric($value) && ! is_bool($value))) {
             throw new FieldTypeException(self::class.' value must be a string.');
         }
 

--- a/packages/core/src/FieldTypes/Text.php
+++ b/packages/core/src/FieldTypes/Text.php
@@ -60,7 +60,7 @@ class Text implements FieldType, JsonSerializable
      */
     public function setValue($value)
     {
-        if ($value && ! is_string($value)) {
+        if ($value && (!is_string($value) && !is_numeric($value) && !is_bool($value))) {
             throw new FieldTypeException(self::class.' value must be a string.');
         }
 

--- a/packages/core/tests/Unit/FieldTypes/TextTest.php
+++ b/packages/core/tests/Unit/FieldTypes/TextTest.php
@@ -6,6 +6,9 @@ use GetCandy\Exceptions\FieldTypeException;
 use GetCandy\FieldTypes\Text;
 use GetCandy\Tests\TestCase;
 
+/**
+ * @group fieldtypes
+ */
 class TextTest extends TestCase
 {
     /** @test */
@@ -15,7 +18,18 @@ class TextTest extends TestCase
         $field->setValue('I like cake');
 
         $this->assertEquals('I like cake', $field->getValue());
+
+        $field = new Text();
+        $field->setValue(12345);
+
+        $this->assertEquals(12345, $field->getValue());
+
+        $field = new Text();
+        $field->setValue(true);
+
+        $this->assertEquals(true, $field->getValue());
     }
+
 
     /** @test */
     public function can_set_null_value()

--- a/packages/core/tests/Unit/FieldTypes/TextTest.php
+++ b/packages/core/tests/Unit/FieldTypes/TextTest.php
@@ -30,7 +30,6 @@ class TextTest extends TestCase
         $this->assertEquals(true, $field->getValue());
     }
 
-
     /** @test */
     public function can_set_null_value()
     {


### PR DESCRIPTION
Currently, anything other than a string gets rejected.  Doesn't help for numeric values or similar.