### PR TITLE
Tweak `HasTranslations` logic to handle other fieldtypes.

### DIFF
--- a/packages/core/src/Base/Traits/HasTranslations.php
+++ b/packages/core/src/Base/Traits/HasTranslations.php
@@ -52,7 +52,7 @@ trait HasTranslations
 
         $translations = $field->getValue();
 
-        if (!is_iterable($translations) || ! $translations) {
+        if (! is_iterable($translations) || ! $translations) {
             return $translations;
         }
 

--- a/packages/core/src/Base/Traits/HasTranslations.php
+++ b/packages/core/src/Base/Traits/HasTranslations.php
@@ -52,7 +52,7 @@ trait HasTranslations
 
         $translations = $field->getValue();
 
-        if (is_string($translations) || ! $translations) {
+        if (!is_iterable($translations) || ! $translations) {
             return $translations;
         }
 

--- a/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
+++ b/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
@@ -242,7 +242,7 @@ class HasTranslationsTest extends TestCase
                     'Two',
                     'Three',
                 ]),
-                'dropdown'        => new Dropdown('Foobar')
+                'dropdown'        => new Dropdown('Foobar'),
             ],
         ]);
 

--- a/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
+++ b/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
@@ -2,6 +2,8 @@
 
 namespace GetCandy\Tests\Unit\Console;
 
+use GetCandy\FieldTypes\Dropdown;
+use GetCandy\FieldTypes\ListField;
 use GetCandy\FieldTypes\Text;
 use GetCandy\FieldTypes\TranslatedText;
 use GetCandy\Models\AttributeGroup;
@@ -218,5 +220,34 @@ class HasTranslationsTest extends TestCase
         ]);
 
         $this->assertNull($product->translateAttribute('description'));
+    }
+
+    /**
+     * @test
+     * */
+    public function handle_if_we_try_and_translate_a_non_translatable_attribute()
+    {
+        AttributeGroup::factory()->create([
+            'name' => [
+                'en' => 'English',
+                'fr' => 'French',
+            ],
+        ]);
+
+        $product = Product::factory()->create([
+            'attribute_data' => [
+                'name'        => new Text('Test Name'),
+                'list'        => new ListField([
+                    'One',
+                    'Two',
+                    'Three',
+                ]),
+                'dropdown'        => new Dropdown('Foobar')
+            ],
+        ]);
+
+        $this->assertEquals('Test Name', $product->translateAttribute('name'));
+        $this->assertEquals('Foobar', $product->translateAttribute('dropdown'));
+        $this->assertEquals(['One', 'Two', 'Three'], $product->translateAttribute('list'));
     }
 }


### PR DESCRIPTION
The `translateAttribute()` method should be able to handle other field types, not just `TranslatedText`