### PR TITLE
Tweak to Meilisearch set up only effect indexes on this install.

### DIFF
--- a/packages/core/src/Console/Commands/MeilisearchSetup.php
+++ b/packages/core/src/Console/Commands/MeilisearchSetup.php
@@ -55,15 +55,14 @@ class MeilisearchSetup extends Command
             $indexName = (new $searchable())->searchableAs();
 
             try {
-                $this->engine->getIndex($indexName);
+                $index = $this->engine->getIndex($indexName);
             } catch (ApiException $e) {
                 $this->info("Creating index for {$searchable}");
                 $this->engine->createIndex($indexName);
-            }
-        }
 
-        foreach ($this->engine->getAllIndexes() as $index) {
-            // Set up soft deletes.
+                $index = $this->engine->getIndex($indexName);
+            }
+
             $index->updateFilterableAttributes([
                 '__soft_deleted',
             ]);


### PR DESCRIPTION
Currently, we update the `__soft_deleted` attribute across all indexes, we should really only be trying to update ones that are part of this install.