### PR TITLE
Fix rich text attribute creation in getcandy:install command

### DIFF
--- a/packages/admin/resources/views/field-types/text/settings.blade.php
+++ b/packages/admin/resources/views/field-types/text/settings.blade.php
@@ -4,5 +4,5 @@
   :error="$errors->first('attribute.configuration.richtext')"
   :disabled="!!$attribute->system"
 >
-  <x-hub::input.toggle :disabled="!!$attribute->system" wire:model="attribute.configuration.richtext" id="fieldType" />
+  <x-hub::input.toggle :disabled="!!$attribute->system" :on-value="true" :off-value="false" wire:model="attribute.configuration.richtext" id="fieldType" />
 </x-hub::input.group>

--- a/packages/core/src/Console/InstallGetCandy.php
+++ b/packages/core/src/Console/InstallGetCandy.php
@@ -182,7 +182,7 @@ class InstallGetCandy extends Command
                     'required'      => true,
                     'default_value' => null,
                     'configuration' => [
-                        'type' => 'text',
+                        'richtext' => false,
                     ],
                     'system' => true,
                 ]);
@@ -200,7 +200,7 @@ class InstallGetCandy extends Command
                     'required'      => true,
                     'default_value' => null,
                     'configuration' => [
-                        'type' => 'text',
+                        'richtext' => false,
                     ],
                     'system' => true,
                 ]);
@@ -218,7 +218,7 @@ class InstallGetCandy extends Command
                     'required'      => false,
                     'default_value' => null,
                     'configuration' => [
-                        'type' => 'richtext',
+                        'richtext' => true,
                     ],
                     'system' => false,
                 ]);
@@ -236,7 +236,7 @@ class InstallGetCandy extends Command
                     'required'      => false,
                     'default_value' => null,
                     'configuration' => [
-                        'type' => 'richtext',
+                        'richtext' => true,
                     ],
                     'system' => false,
                 ]);


### PR DESCRIPTION
The install command creates default attributes with the wrong configuration.
For rich text it is
```json
{
    "type": "richtext"
}
```
instead of
```json
{
    "richtext": "1"
}
```

and for regular text fields it is:
```json
{
    "type": "text"
}
```
instead of
```json
{
    "richtext": null
}
```