### PR TITLE
Bug: don't assume unit quantity is 1

### DIFF
--- a/packages/admin/src/Actions/Pricing/UpdateTieredPricing.php
+++ b/packages/admin/src/Actions/Pricing/UpdateTieredPricing.php
@@ -42,7 +42,7 @@ class UpdateTieredPricing
                 }
             }
 
-            $owner->prices()->whereNotIn('id', $pricesToKeep)->where('tier', '>', 1)->delete();
+            $owner->prices()->whereNotIn('id', $pricesToKeep)->where('tier', '>', $owner->unit_quantity)->delete();
         });
 
         return collect($tiers)->sortBy('tier')->values();


### PR DESCRIPTION
When removing tiered pricing items don't assume the base unit is 1, as its editable

(unless I've misunderstood how you see unit_quantity working)