### PR TITLE
Only calculate unit price if it doesn't already exist

### DIFF
--- a/packages/core/src/Actions/Carts/CalculateLine.php
+++ b/packages/core/src/Actions/Carts/CalculateLine.php
@@ -33,23 +33,27 @@ class CalculateLine
         $purchasable = $cartLine->purchasable;
         $cart = $cartLine->cart;
         $unitQuantity = $purchasable->getUnitQuantity();
+                
+        if (! ($unitPrice = $cartLine->unitPrice) instanceof Price) {
 
-        $priceResponse = Pricing::currency($cart->currency)
-            ->qty($cartLine->quantity)
-            ->currency($cart->currency)
-            ->customerGroups($customerGroups)
-            ->for($purchasable);
-
-        $price = new Price(
-            $priceResponse->matched->price->value,
-            $cart->currency,
-            $purchasable->getUnitQuantity()
-        );
-
-        $unitPrice = (int) (round(
-            $price->decimal / $purchasable->getUnitQuantity(),
-            $cart->currency->decimal_places
-        ) * $cart->currency->factor);
+            $priceResponse = Pricing::currency($cart->currency)
+                ->qty($cartLine->quantity)
+                ->currency($cart->currency)
+                ->customerGroups($customerGroups)
+                ->for($purchasable);
+    
+            $price = new Price(
+                $priceResponse->matched->price->value,
+                $cart->currency,
+                $purchasable->getUnitQuantity()
+            );
+    
+            $unitPrice = (int) (round(
+                $price->decimal / $purchasable->getUnitQuantity(),
+                $cart->currency->decimal_places
+            ) * $cart->currency->factor);
+            
+        }
 
         $subTotal = $unitPrice * $cartLine->quantity;
 


### PR DESCRIPTION
@alecritson here is what I was thinking... basically only calculate the unit price if the unit price is not already an instance of `Price`.

This allows cart line modifiers to set a price at the `calculating()` stage and still benefit from the other calculations such as tax etc
