### PR TITLE
Added AddressObserver and ensures that only one default and billing shipping address per customers exists

### DIFF
--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -29,6 +29,7 @@ use GetCandy\Listeners\CartSessionAuthListener;
 use GetCandy\Managers\CartSessionManager;
 use GetCandy\Managers\PricingManager;
 use GetCandy\Managers\TaxManager;
+use GetCandy\Models\Address;
 use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Collection;
@@ -36,6 +37,7 @@ use GetCandy\Models\Currency;
 use GetCandy\Models\Language;
 use GetCandy\Models\OrderLine;
 use GetCandy\Models\Url;
+use GetCandy\Observers\AddressObserver;
 use GetCandy\Observers\CartLineObserver;
 use GetCandy\Observers\ChannelObserver;
 use GetCandy\Observers\CollectionObserver;
@@ -222,6 +224,7 @@ class GetCandyServiceProvider extends ServiceProvider
         Collection::observe(CollectionObserver::class);
         CartLine::observe(CartLineObserver::class);
         OrderLine::observe(OrderLineObserver::class);
+        Address::observe(AddressObserver::class);
     }
 
     /**

--- a/packages/core/src/Models/Address.php
+++ b/packages/core/src/Models/Address.php
@@ -30,6 +30,16 @@ class Address extends BaseModel implements Addressable
     protected $guarded = [];
 
     /**
+     * Define attribute casting.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'shipping_default' => 'boolean',
+        'billing_default' => 'boolean',
+    ];
+
+    /**
      * Mutator for the meta attribute.
      *
      * @param  array|null  $value

--- a/packages/core/src/Observers/AddressObserver.php
+++ b/packages/core/src/Observers/AddressObserver.php
@@ -33,7 +33,7 @@ class AddressObserver
     /**
      * Ensures that only one default shipping address exists.
      *
-     * @param Address $address
+     * @param  Address $address
      */
     protected function ensureOnlyOneDefaultShipping(Address $address): void
     {
@@ -53,7 +53,7 @@ class AddressObserver
     /**
      * Ensures that only one default billing address exists.
      *
-     * @param Address $address
+     * @param  Address $address
      */
     protected function ensureOnlyOneDefaultBilling(Address $address): void
     {

--- a/packages/core/src/Observers/AddressObserver.php
+++ b/packages/core/src/Observers/AddressObserver.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace GetCandy\Observers;
+
+use GetCandy\Models\Address;
+
+class AddressObserver
+{
+    /**
+     * Handle the Address "creating" event.
+     *
+     * @param  \GetCandy\Models\Address  $address
+     * @return void
+     */
+    public function creating(Address $address)
+    {
+        $this->ensureOnlyOneDefaultShipping($address);
+        $this->ensureOnlyOneDefaultBilling($address);
+    }
+
+    /**
+     * Handle the Address "updating" event.
+     *
+     * @param  \GetCandy\Models\Address  $address
+     * @return void
+     */
+    public function updating(Address $address)
+    {
+        $this->ensureOnlyOneDefaultShipping($address);
+        $this->ensureOnlyOneDefaultBilling($address);
+    }
+
+    /**
+     * Ensures that only one default shipping address exists.
+     *
+     * @param Address $address
+     */
+    protected function ensureOnlyOneDefaultShipping(Address $address): void
+    {
+        if ($address->shipping_default) {
+            $address = Address::query()
+                ->whereCustomerId($address->customer_id)
+                ->whereShippingDefault(true)
+                ->first();
+
+            if ($address) {
+                $address->shipping_default = false;
+                $address->saveQuietly();
+            }
+        }
+    }
+
+    /**
+     * Ensures that only one default billing address exists.
+     *
+     * @param Address $address
+     */
+    protected function ensureOnlyOneDefaultBilling(Address $address): void
+    {
+        if ($address->billing_default) {
+            $address = Address::query()
+                ->whereCustomerId($address->customer_id)
+                ->whereBillingDefault(true)
+                ->first();
+
+            if ($address) {
+                $address->billing_default = false;
+                $address->saveQuietly();
+            }
+        }
+    }
+}

--- a/packages/core/src/Observers/AddressObserver.php
+++ b/packages/core/src/Observers/AddressObserver.php
@@ -33,7 +33,7 @@ class AddressObserver
     /**
      * Ensures that only one default shipping address exists.
      *
-     * @param  Address $address
+     * @param  Address  $address  The address that will be saved.
      */
     protected function ensureOnlyOneDefaultShipping(Address $address): void
     {
@@ -53,7 +53,7 @@ class AddressObserver
     /**
      * Ensures that only one default billing address exists.
      *
-     * @param  Address $address
+     * @param  Address  $address  The address that will be saved.
      */
     protected function ensureOnlyOneDefaultBilling(Address $address): void
     {

--- a/packages/core/tests/Unit/Observers/AddressObserverTest.php
+++ b/packages/core/tests/Unit/Observers/AddressObserverTest.php
@@ -17,82 +17,56 @@ class AddressObserverTest extends TestCase
     /** @test */
     public function can_only_have_one_shipping_default_per_customer()
     {
-        $customerA = Customer::factory()->create();
+        $customer = Customer::factory()->create();
 
-        $addressADefault = Address::factory()->create([
-            'customer_id' => $customerA->id,
+        $addressA = Address::factory()->create([
+            'customer_id' => $customer->id,
             'shipping_default' => true,
         ]);
 
-        $this->assertTrue($addressADefault->shipping_default);
+        $this->assertTrue($addressA->shipping_default);
 
-        $addressANewDefault = Address::factory()->create([
-            'customer_id' => $customerA->id,
+        $addressB = Address::factory()->create([
+            'customer_id' => $customer->id,
             'shipping_default' => true,
         ]);
 
-        $this->assertFalse($addressADefault->refresh()->shipping_default);
-        $this->assertTrue($addressANewDefault->shipping_default);
+        $this->assertFalse($addressA->refresh()->shipping_default);
+        $this->assertTrue($addressB->shipping_default);
 
-        $customerB = Customer::factory()->create();
-
-        $addressBDefault = Address::factory()->create([
-            'customer_id' => $customerB->id,
+        $addressA->update([
             'shipping_default' => true,
         ]);
 
-        $this->assertTrue($addressBDefault->shipping_default);
-
-        $addressBNewDefault = Address::factory()->create([
-            'customer_id' => $customerB->id,
-            'shipping_default' => true,
-        ]);
-
-        $this->assertFalse($addressBDefault->refresh()->shipping_default);
-        $this->assertTrue($addressBNewDefault->shipping_default);
-
-        $this->assertFalse($addressADefault->refresh()->shipping_default);
-        $this->assertTrue($addressANewDefault->refresh()->shipping_default);
+        $this->assertTrue($addressA->shipping_default);
+        $this->assertFalse($addressB->refresh()->shipping_default);
     }
 
     /** @test */
     public function can_only_have_one_billing_default_per_customer()
     {
-        $customerA = Customer::factory()->create();
+        $customer = Customer::factory()->create();
 
-        $addressADefault = Address::factory()->create([
-            'customer_id' => $customerA->id,
+        $addressA = Address::factory()->create([
+            'customer_id' => $customer->id,
             'billing_default' => true,
         ]);
 
-        $this->assertTrue($addressADefault->billing_default);
+        $this->assertTrue($addressA->billing_default);
 
-        $addressANewDefault = Address::factory()->create([
-            'customer_id' => $customerA->id,
+        $addressB = Address::factory()->create([
+            'customer_id' => $customer->id,
             'billing_default' => true,
         ]);
 
-        $this->assertFalse($addressADefault->refresh()->billing_default);
-        $this->assertTrue($addressANewDefault->billing_default);
+        $this->assertFalse($addressA->refresh()->billing_default);
+        $this->assertTrue($addressB->billing_default);
 
-        $customerB = Customer::factory()->create();
-
-        $addressBDefault = Address::factory()->create([
-            'customer_id' => $customerB->id,
+        $addressA->update([
             'billing_default' => true,
         ]);
 
-        $this->assertTrue($addressBDefault->billing_default);
-
-        $addressBNewDefault = Address::factory()->create([
-            'customer_id' => $customerB->id,
-            'billing_default' => true,
-        ]);
-
-        $this->assertFalse($addressBDefault->refresh()->billing_default);
-        $this->assertTrue($addressBNewDefault->billing_default);
-
-        $this->assertFalse($addressADefault->refresh()->billing_default);
-        $this->assertTrue($addressANewDefault->refresh()->billing_default);
+        $this->assertTrue($addressA->billing_default);
+        $this->assertFalse($addressB->refresh()->billing_default);
     }
 }

--- a/packages/core/tests/Unit/Observers/AddressObserverTest.php
+++ b/packages/core/tests/Unit/Observers/AddressObserverTest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Observers;
+
+use GetCandy\Models\Address;
+use GetCandy\Models\Customer;
+use GetCandy\Models\Language;
+use GetCandy\Models\Url;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group observers
+ */
+class AddressObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_only_have_one_shipping_default_per_customer()
+    {
+        $customerA = Customer::factory()->create();
+
+        $addressADefault = Address::factory()->create([
+            'customer_id' => $customerA->id,
+            'shipping_default' => true,
+        ]);
+
+        $this->assertTrue($addressADefault->shipping_default);
+
+        $addressANewDefault = Address::factory()->create([
+            'customer_id' => $customerA->id,
+            'shipping_default' => true,
+        ]);
+
+        $this->assertFalse($addressADefault->refresh()->shipping_default);
+        $this->assertTrue($addressANewDefault->shipping_default);
+
+        $customerB = Customer::factory()->create();
+
+        $addressBDefault = Address::factory()->create([
+            'customer_id' => $customerB->id,
+            'shipping_default' => true,
+        ]);
+
+        $this->assertTrue($addressBDefault->shipping_default);
+
+        $addressBNewDefault = Address::factory()->create([
+            'customer_id' => $customerB->id,
+            'shipping_default' => true,
+        ]);
+
+        $this->assertFalse($addressBDefault->refresh()->shipping_default);
+        $this->assertTrue($addressBNewDefault->shipping_default);
+
+        $this->assertFalse($addressADefault->refresh()->shipping_default);
+        $this->assertTrue($addressANewDefault->refresh()->shipping_default);
+    }
+
+    /** @test */
+    public function can_only_have_one_billing_default_per_customer()
+    {
+        $customerA = Customer::factory()->create();
+
+        $addressADefault = Address::factory()->create([
+            'customer_id' => $customerA->id,
+            'billing_default' => true,
+        ]);
+
+        $this->assertTrue($addressADefault->billing_default);
+
+        $addressANewDefault = Address::factory()->create([
+            'customer_id' => $customerA->id,
+            'billing_default' => true,
+        ]);
+
+        $this->assertFalse($addressADefault->refresh()->billing_default);
+        $this->assertTrue($addressANewDefault->billing_default);
+
+        $customerB = Customer::factory()->create();
+
+        $addressBDefault = Address::factory()->create([
+            'customer_id' => $customerB->id,
+            'billing_default' => true,
+        ]);
+
+        $this->assertTrue($addressBDefault->billing_default);
+
+        $addressBNewDefault = Address::factory()->create([
+            'customer_id' => $customerB->id,
+            'billing_default' => true,
+        ]);
+
+        $this->assertFalse($addressBDefault->refresh()->billing_default);
+        $this->assertTrue($addressBNewDefault->billing_default);
+
+        $this->assertFalse($addressADefault->refresh()->billing_default);
+        $this->assertTrue($addressANewDefault->refresh()->billing_default);
+    }
+}

--- a/packages/core/tests/Unit/Observers/AddressObserverTest.php
+++ b/packages/core/tests/Unit/Observers/AddressObserverTest.php
@@ -4,8 +4,6 @@ namespace GetCandy\Tests\Unit\Observers;
 
 use GetCandy\Models\Address;
 use GetCandy\Models\Customer;
-use GetCandy\Models\Language;
-use GetCandy\Models\Url;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 


### PR DESCRIPTION
- Ensures that only one default shipping address per customers exists.
- Ensures that only one default billing address per customers exists.
