### PR TITLE
Use register instead of boot for container bindings

### DIFF
--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -86,7 +86,9 @@ class AdminHubServiceProvider extends ServiceProvider
             $this->mergeConfigFrom("{$this->root}/config/$config.php", "getcandy-hub.$config");
         });
 
-        $this->app->instance(Manifest::class, new Manifest());
+        $this->app->singleton(Manifest::class, function () {
+            return new Manifest();
+        });
 
         $this->app->singleton(MenuRegistry::class, function () {
             return new MenuRegistry();

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -79,55 +79,8 @@ class GetCandyServiceProvider extends ServiceProvider
         });
 
         $this->loadTranslationsFrom(__DIR__.'/../resources/lang', 'getcandy');
-    }
 
-    /**
-     * Bootstrap any application services.
-     *
-     * @return void
-     */
-    public function boot(): void
-    {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
-
-        Relation::morphMap([
-            'product_type' => GetCandy\Models\ProductType::class,
-            //'order' => GetCandy\Models\Order::class,
-        ]);
-
-        $this->registerObservers();
         $this->registerAddonManifest();
-        $this->registerBlueprintMacros();
-
-        if (! $this->app->environment('testing')) {
-            $this->registerStateListeners();
-        }
-
-        if ($this->app->runningInConsole()) {
-            collect($this->configFiles)->each(function ($config) {
-                $this->publishes([
-                    "{$this->root}/config/$config.php" => config_path("getcandy/$config.php"),
-                ], 'getcandy');
-            });
-
-            $this->commands([
-                InstallGetCandy::class,
-                AddonsDiscover::class,
-                MeilisearchSetup::class,
-                AddressData::class,
-            ]);
-        }
-
-        Arr::macro('permutate', [\GetCandy\Utils\Arr::class, 'permutate']);
-
-        // Handle generator
-        Str::macro('handle', function ($string) {
-            return Str::slug($string, '_');
-        });
-
-        Converter::setMeasurements(
-            config('getcandy.shipping.measurements', [])
-        );
 
         $this->app->singleton(CartModifiers::class, function () {
             return new CartModifiers();
@@ -172,6 +125,54 @@ class GetCandyServiceProvider extends ServiceProvider
         $this->app->singleton(TaxManagerInterface::class, function ($app) {
             return $app->make(TaxManager::class);
         });
+    }
+
+    /**
+     * Bootstrap any application services.
+     *
+     * @return void
+     */
+    public function boot(): void
+    {
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+
+        Relation::morphMap([
+            'product_type' => GetCandy\Models\ProductType::class,
+            //'order' => GetCandy\Models\Order::class,
+        ]);
+
+        $this->registerObservers();
+        $this->registerBlueprintMacros();
+
+        if (! $this->app->environment('testing')) {
+            $this->registerStateListeners();
+        }
+
+        if ($this->app->runningInConsole()) {
+            collect($this->configFiles)->each(function ($config) {
+                $this->publishes([
+                    "{$this->root}/config/$config.php" => config_path("getcandy/$config.php"),
+                ], 'getcandy');
+            });
+
+            $this->commands([
+                InstallGetCandy::class,
+                AddonsDiscover::class,
+                MeilisearchSetup::class,
+                AddressData::class,
+            ]);
+        }
+
+        Arr::macro('permutate', [\GetCandy\Utils\Arr::class, 'permutate']);
+
+        // Handle generator
+        Str::macro('handle', function ($string) {
+            return Str::slug($string, '_');
+        });
+
+        Converter::setMeasurements(
+            config('getcandy.shipping.measurements', [])
+        );
 
         Event::listen(
             Login::class,


### PR DESCRIPTION
This is a issue, because if a service provider is loaded before the package service provider, no bindings are available.

Laravel calls register first on all providers and then boot, as such it's recommended all bindings are registered in the register method.
