### PR TITLE
Feat/cart improvements

### DIFF
--- a/docs/src/getcandy/orders.md
+++ b/docs/src/getcandy/orders.md
@@ -41,7 +41,15 @@ You can either create an order directly, or the recommended way is via a `Cart` 
 $order = \GetCandy\Models\Order::create([/** .. */]);
 
 // Recommended way
-$cart = Cart::first()->getManager()->createOrder();
+$order = Cart::first()->getManager()->createOrder();
+```
+
+If you are using the `CartSession` you can create a cart via the facade, this will then handle removing the cart from the session if you want it to.
+
+```php
+$order = CartSession::createOrder(
+    forget: true
+);
 ```
 
 So what's happening when we call `createOrder` on a cart, that's so different from just creating an order manually? Well there's a few steps GetCandy takes to make sure data stays consistent and valid, it also means that a lot of the columns on an order will automatically be populated based on the cart.
@@ -85,7 +93,7 @@ This essentially does the same as above, except we already catch the exceptions 
 
 ## Modifying Orders
 
-If you need to programatically change the Order values or add in new behaviour, you will want to extend the Order system. 
+If you need to programatically change the Order values or add in new behaviour, you will want to extend the Order system.
 
 You can find out more in the Extending GetCandy section for [Order Modifiers](/extending/order-modifiers).
 
@@ -188,7 +196,7 @@ $order->billingAddress;
 A Shipping Tables addon is planned to make setting up shipping in the admin hub easy for most scenarios.
 :::
 
-To add Shipping Options you will need to [extend GetCandy](/extending/shipping) to add in your own logic. 
+To add Shipping Options you will need to [extend GetCandy](/extending/shipping) to add in your own logic.
 
 Then in your checkout, or where ever you want, you can fetch these options:
 

--- a/docs/src/getcandy/orders.md
+++ b/docs/src/getcandy/orders.md
@@ -44,13 +44,19 @@ $order = \GetCandy\Models\Order::create([/** .. */]);
 $order = Cart::first()->getManager()->createOrder();
 ```
 
-If you are using the `CartSession` you can create a cart via the facade, this will then handle removing the cart from the session if you want it to.
+If you are using the `CartSession` you can create a order via the facade, this will then handle removing the cart from the session if you want it to.
 
 ```php
-$order = CartSession::createOrder(
-    forget: true
-);
+$order = CartSession::createOrder();
 ```
+
+By default, this will create the order and remove the cart id from the session. You can, however retain the cart id if you want by passing an option `boolean` parameter to the method:
+
+```php
+$order = CartSession::createOrder(false);
+```
+
+Now when you create the order, you will still have the cart id in the session.
 
 So what's happening when we call `createOrder` on a cart, that's so different from just creating an order manually? Well there's a few steps GetCandy takes to make sure data stays consistent and valid, it also means that a lot of the columns on an order will automatically be populated based on the cart.
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+- Added `createOrder($forget = true)` method to the `CartSession` facade.
+
 ## 2.0-beta10 - 2022-02-18
 
 ### Added

--- a/packages/core/database/factories/CartAddressFactory.php
+++ b/packages/core/database/factories/CartAddressFactory.php
@@ -2,13 +2,13 @@
 
 namespace GetCandy\Database\Factories;
 
-use GetCandy\Models\Address;
+use GetCandy\Models\CartAddress;
 use GetCandy\Models\Country;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class CartAddressFactory extends Factory
 {
-    protected $model = Address::class;
+    protected $model = CartAddress::class;
 
     public function definition(): array
     {

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -178,6 +178,21 @@ class CartSessionManager implements CartSessionInterface
     }
 
     /**
+     * Create an order from a cart instance.
+     *
+     * @param boolean $forget
+     * @return \GetCandy\Models\Order
+     */
+    public function createOrder($forget = true)
+    {
+        if ($forget) {
+            $this->forget();
+        }
+
+        return $this->manager()->createOrder();
+    }
+
+    /**
      * Create a new cart instance.
      *
      * @return void

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -180,7 +180,7 @@ class CartSessionManager implements CartSessionInterface
     /**
      * Create an order from a cart instance.
      *
-     * @param boolean $forget
+     * @param  bool  $forget
      * @return \GetCandy\Models\Order
      */
     public function createOrder($forget = true)

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -8,6 +8,9 @@ use GetCandy\Base\DataTransferObjects\TaxBreakdown;
 use GetCandy\Base\Purchasable;
 use GetCandy\DataTypes\Price;
 use GetCandy\Exceptions\CartLineIdMismatchException;
+use GetCandy\Exceptions\Carts\BillingAddressIncompleteException;
+use GetCandy\Exceptions\Carts\BillingAddressMissingException;
+use GetCandy\Exceptions\Carts\OrderExistsException;
 use GetCandy\Exceptions\InvalidCartLineQuantityException;
 use GetCandy\Exceptions\MaximumCartLineQuantityException;
 use GetCandy\Managers\CartManager;
@@ -17,6 +20,7 @@ use GetCandy\Models\CartLine;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Currency;
 use GetCandy\Models\CustomerGroup;
+use GetCandy\Models\Order;
 use GetCandy\Models\Price as PriceModel;
 use GetCandy\Models\ProductVariant;
 use GetCandy\Models\TaxClass;
@@ -746,5 +750,111 @@ class CartManagerTest extends TestCase
 
         $this->assertInstanceOf(TaxBreakdown::class, $line->taxBreakdown);
         $this->assertCount(1, $line->taxBreakdown->amounts);
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_order()
+    {
+        $currency = Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $channel = Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $shipping = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping'
+        ]);
+
+        $billing = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing'
+        ]);
+
+        $cart->getManager()->setShippingAddress($shipping);
+        $cart->getManager()->setBillingAddress($billing);
+
+        $order = $cart->getManager()->createOrder();
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals($cart->order_id, $order->id);
+    }
+
+    /**
+     * @test
+     */
+    public function cant_create_order_from_incomplete_cart()
+    {
+        $currency = Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $channel = Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+        ]);
+
+        $this->expectException(BillingAddressMissingException::class);
+
+        $cart->getManager()->createOrder();
+
+        Cart::create([
+            'cart_id' => $cart->id,
+            'postcode' => 'foobar',
+            'type' => 'billing'
+        ]);
+
+        $this->expectException(BillingAddressIncompleteException::class);
+
+        $cart->getManager()->createOrder();
+    }
+
+    /**
+     * @test
+     */
+    public function cant_create_order_for_cart_with_existing_order()
+    {
+        $currency = Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        $channel = Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        $order = Order::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+            'channel_id' => $channel->id,
+            'order_id' => $order->id,
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping'
+        ]);
+
+        CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing'
+        ]);
+
+        $this->expectException(OrderExistsException::class);
+
+        $cart->getManager()->createOrder();
     }
 }

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -772,12 +772,12 @@ class CartManagerTest extends TestCase
 
         $shipping = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'shipping'
+            'type' => 'shipping',
         ]);
 
         $billing = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'billing'
+            'type' => 'billing',
         ]);
 
         $cart->getManager()->setShippingAddress($shipping);
@@ -814,7 +814,7 @@ class CartManagerTest extends TestCase
         Cart::create([
             'cart_id' => $cart->id,
             'postcode' => 'foobar',
-            'type' => 'billing'
+            'type' => 'billing',
         ]);
 
         $this->expectException(BillingAddressIncompleteException::class);
@@ -845,12 +845,12 @@ class CartManagerTest extends TestCase
 
         CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'shipping'
+            'type' => 'shipping',
         ]);
 
         CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'billing'
+            'type' => 'billing',
         ]);
 
         $this->expectException(OrderExistsException::class);

--- a/packages/core/tests/Unit/Managers/CartSessionManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartSessionManagerTest.php
@@ -82,12 +82,12 @@ class CartSessionManagerTest extends TestCase
 
         $shipping = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'shipping'
+            'type' => 'shipping',
         ]);
 
         $billing = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'billing'
+            'type' => 'billing',
         ]);
 
         $cart->getManager()->setShippingAddress($shipping);
@@ -127,12 +127,12 @@ class CartSessionManagerTest extends TestCase
 
         $shipping = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'shipping'
+            'type' => 'shipping',
         ]);
 
         $billing = CartAddress::factory()->create([
             'cart_id' => $cart->id,
-            'type' => 'billing'
+            'type' => 'billing',
         ]);
 
         $cart->getManager()->setShippingAddress($shipping);

--- a/packages/core/tests/Unit/Managers/CartSessionManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartSessionManagerTest.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Managers;
+
+use GetCandy\Facades\CartSession;
+use GetCandy\Managers\CartSessionManager;
+use GetCandy\Models\Cart;
+use GetCandy\Models\CartAddress;
+use GetCandy\Models\Channel;
+use GetCandy\Models\Currency;
+use GetCandy\Models\Order;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Session;
+
+/**
+ * @group getcandy.cart-session-manager
+ */
+class CartSessionManagerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function can_instantiate_manager()
+    {
+        $manager = app(CartSessionManager::class);
+        $this->assertInstanceOf(CartSessionManager::class, $manager);
+    }
+
+    /**
+     * @test
+     */
+    public function can_fetch_current_cart()
+    {
+        $manager = app(CartSessionManager::class);
+
+        Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        Config::set('getcandy.cart.auto_create', false);
+
+        $cart = $manager->current();
+
+        $this->assertNull($cart);
+
+        Config::set('getcandy.cart.auto_create', true);
+
+        $cart = $manager->current();
+
+        $this->assertInstanceOf(Cart::class, $cart);
+
+        $sessionCart = Session::get(config('getcandy.cart.session_key'));
+
+        $this->assertNotNull($sessionCart);
+        $this->assertEquals($cart->id, $sessionCart);
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_order_from_session_cart_and_cleanup()
+    {
+        Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        Config::set('getcandy.cart.auto_create', true);
+
+        $cart = CartSession::current();
+
+        $shipping = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping'
+        ]);
+
+        $billing = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing'
+        ]);
+
+        $cart->getManager()->setShippingAddress($shipping);
+        $cart->getManager()->setBillingAddress($billing);
+
+        $sessionCart = Session::get(config('getcandy.cart.session_key'));
+
+        $this->assertNotNull($sessionCart);
+        $this->assertEquals($cart->id, $sessionCart);
+
+        $order = CartSession::createOrder();
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals($cart->order_id, $order->id);
+
+        $this->assertNull(
+            Session::get(config('getcandy.cart.session_key'))
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function can_create_order_from_session_cart_and_retain_cart()
+    {
+        Currency::factory()->create([
+            'default' => true,
+        ]);
+
+        Channel::factory()->create([
+            'default' => true,
+        ]);
+
+        Config::set('getcandy.cart.auto_create', true);
+
+        $cart = CartSession::current();
+
+        $shipping = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'shipping'
+        ]);
+
+        $billing = CartAddress::factory()->create([
+            'cart_id' => $cart->id,
+            'type' => 'billing'
+        ]);
+
+        $cart->getManager()->setShippingAddress($shipping);
+        $cart->getManager()->setBillingAddress($billing);
+
+        $sessionCart = Session::get(config('getcandy.cart.session_key'));
+
+        $this->assertNotNull($sessionCart);
+        $this->assertEquals($cart->id, $sessionCart);
+
+        $order = CartSession::createOrder(
+            forget: false
+        );
+
+        $this->assertInstanceOf(Order::class, $order);
+        $this->assertEquals($cart->order_id, $order->id);
+
+        $this->assertEquals(
+            $cart->id,
+            Session::get(config('getcandy.cart.session_key'))
+        );
+    }
+}


### PR DESCRIPTION
This PR looks to add a `createOrder` method to the `CartSession` facade.

The reasoning for this is when you want to create an order from a cart, you may wish for the cart session to forget the cart.

Usage:

```php
\GetCandy\Facades\CartSession::createOrder();
```

This will create the order and remove the cart id from the session.

```php
\GetCandy\Facades\CartSession::createOrder(
    forget: false
);
```

This will create the order but retain the cart id in the session.

---

There are some extra tests in this that I felt were missing and should help with the included methods.