### PR TITLE
Feat/search improvements

### DIFF
--- a/docs/src/.vuepress/config.js
+++ b/docs/src/.vuepress/config.js
@@ -120,6 +120,7 @@ module.exports = {
           '/extending/field-types',
           '/extending/models',
           '/extending/order-modifiers',
+          '/extending/search',
           '/extending/shipping',
           '/extending/taxation',
         ]

--- a/docs/src/extending/search.md
+++ b/docs/src/extending/search.md
@@ -1,0 +1,68 @@
+# Search
+
+[[toc]]
+
+## Overview
+
+Good search is the backbone of any storefront so GetCandy aims to make this as extensible as possible so you can index what you need for your front end, without compromising on what we require our side in the hub.
+
+There's three things to consider when you want to extend the search:
+
+- Searchable fields
+- Sortable fields
+- Filterable fields
+
+Each of these can be extended using Model Observers in Laravel. The following models can be extended:
+
+- `GetCandy\Models\Collection`
+- `GetCandy\Models\Customer`
+- `GetCandy\Models\Order`
+- `GetCandy\Models\Product`
+- `GetCandy\Models\ProductOption`
+
+## Creating and using an oberver
+
+As mentioned, you simply need to add a [Model Observer](https://laravel.com/docs/9.x/eloquent#observers) for what you want to extend.
+
+```php
+<?php
+
+namespace App\Observers;
+
+use GetCandy\Models\Order;
+
+class OrderObserver
+{
+    /**
+     * Called when we're about to index the order
+     **/
+    public function indexing(Order $order)
+    {
+        $order->addSearchableAttribute(
+            'custom_field',
+            $order->meta->custom_field
+        );
+    }
+
+    /**
+     * Called when we are setting up the index via
+     * php artisan getcandy:meilisearch:update
+     * */
+    public function searchSetup(Order $order)
+    {
+        $order->addFilterableAttributes([
+            'custom_field'
+        ]);
+
+        $order->addSortableAttributes([
+            'custom_field'
+        ]);
+    }
+}
+```
+
+You can then use these fields in your search:
+
+```php
+Product::search('Foo')->where('custom_field', 'Bar');
+```

--- a/docs/src/extending/search.md
+++ b/docs/src/extending/search.md
@@ -4,9 +4,9 @@
 
 ## Overview
 
-Good search is the backbone of any storefront so GetCandy aims to make this as extensible as possible so you can index what you need for your front end, without compromising on what we require our side in the hub.
+Good search is the backbone of any storefront so GetCandy aims to make this as extensible as possible so you can index what you need for your front-end, without compromising on what we require our side in the hub.
 
-There's three things to consider when you want to extend the search:
+There are three things to consider when you want to extend the search:
 
 - Searchable fields
 - Sortable fields
@@ -20,7 +20,7 @@ Each of these can be extended using Model Observers in Laravel. The following mo
 - `GetCandy\Models\Product`
 - `GetCandy\Models\ProductOption`
 
-## Creating and using an oberver
+## Creating and using an Observer
 
 As mentioned, you simply need to add a [Model Observer](https://laravel.com/docs/9.x/eloquent#observers) for what you want to extend.
 

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -30,6 +30,18 @@ If you're using Meilisearch, run the following
 php artisan getcandy:meilisearch:setup
 ```
 
+## [Unreleased]
+
+If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's one if you want to tap into the Model Observers.
+
+```php
+// Old
+use Laravel\Scout\Searchable;
+
+// New
+use GetCandy\Base\Traits\Searchable;
+```
+
 ## 2.0-beta10
 
 ### Changes to Tax drivers - High Impact

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -32,7 +32,7 @@ php artisan getcandy:meilisearch:setup
 
 ## [Unreleased]
 
-If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's one if you want to tap into the Model Observers.
+If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's if you want to tap into the Model Observers.
 
 ```php
 // Old

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Added `createOrder($forget = true)` method to the `CartSession` facade.
 - Added `active` scope to the `Cart` model for carts that do not have an order associated.
+- Added ability to tap into filterable, searchable and sortable fields in Scout.
 
 ### Fixed
 

--- a/packages/core/src/Base/Traits/Searchable.php
+++ b/packages/core/src/Base/Traits/Searchable.php
@@ -16,6 +16,20 @@ trait Searchable
     protected $additionalSearchFields = [];
 
     /**
+     * Define the additional filterable fields.
+     *
+     * @var array
+     */
+    protected $additionalFilterableFields = [];
+
+    /**
+     * Define the additional sortable fields.
+     *
+     * @var array
+     */
+    protected $additionalSortableFields = [];
+
+    /**
      * Return our base (core) attributes we want searchable.
      *
      * @return array
@@ -28,18 +42,63 @@ trait Searchable
     }
 
     /**
-     * Return out base attributes we want filterable.
+     * Return our base attributes we want filterable.
      *
      * @return array
      */
     public function getFilterableAttributes()
     {
-        return [
-            'status',
-            'placed_at',
-            'created_at',
-            'total',
-        ];
+        $this->fireModelEvent('searchSetup');
+
+        return array_merge(
+            $this->filterable ?? [],
+            $this->additionalFilterableFields,
+        );
+    }
+
+    /**
+     * Add additional fields to filter on.
+     *
+     * @param array $attributes
+     * @return void
+     */
+    public function addFilterableAttributes(array $attributes)
+    {
+        collect($attributes)->filter(function ($att) {
+            return !in_array($att, $this->filterable) && !in_array($att, $this->additionalFilterableFields);
+        })->each(function ($att) {
+            $this->additionalFilterableFields[] = $att;
+        });
+    }
+
+    /**
+     * Add additional sortable attributes.
+     *
+     * @param array $attributes
+     * @return void
+     */
+    public function addSortableAttributes(array $attributes)
+    {
+        collect($attributes)->filter(function ($att) {
+            return !in_array($att, $this->sortable) && !in_array($att, $this->additionalSortableFields);
+        })->each(function ($att) {
+            $this->additionalSortableFields[] = $att;
+        });
+    }
+
+    /**
+     * Return our base attributes we want sortable.
+     *
+     * @return array
+     */
+    public function getSortableAttributes()
+    {
+        $this->fireModelEvent('searchSetup');
+
+        return array_merge(
+            $this->sortable ?? [],
+            $this->additionalSortableFields
+        );
     }
 
     /**
@@ -49,6 +108,7 @@ trait Searchable
     {
         return array_merge(parent::getObservableEvents(), [
             'indexing',
+            'searchSetup',
         ]);
     }
 

--- a/packages/core/src/Base/Traits/Searchable.php
+++ b/packages/core/src/Base/Traits/Searchable.php
@@ -59,13 +59,13 @@ trait Searchable
     /**
      * Add additional fields to filter on.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return void
      */
     public function addFilterableAttributes(array $attributes)
     {
         collect($attributes)->filter(function ($att) {
-            return !in_array($att, $this->filterable) && !in_array($att, $this->additionalFilterableFields);
+            return ! in_array($att, $this->filterable) && ! in_array($att, $this->additionalFilterableFields);
         })->each(function ($att) {
             $this->additionalFilterableFields[] = $att;
         });
@@ -74,13 +74,13 @@ trait Searchable
     /**
      * Add additional sortable attributes.
      *
-     * @param array $attributes
+     * @param  array  $attributes
      * @return void
      */
     public function addSortableAttributes(array $attributes)
     {
         collect($attributes)->filter(function ($att) {
-            return !in_array($att, $this->sortable) && !in_array($att, $this->additionalSortableFields);
+            return ! in_array($att, $this->sortable) && ! in_array($att, $this->additionalSortableFields);
         })->each(function ($att) {
             $this->additionalSortableFields[] = $att;
         });
@@ -115,13 +115,13 @@ trait Searchable
     /**
      * Add an attribute into the additional searchable fields.
      *
-     * @param string $key
-     * @param string|mixed $value
+     * @param  string  $key
+     * @param  string|mixed  $value
      * @return void
      */
     public function addSearchableAttribute($key, $value)
     {
-        if (!isset($this->additionalSearchFields[$key])) {
+        if (! isset($this->additionalSearchFields[$key])) {
             $this->additionalSearchFields[$key] = $value;
         }
     }

--- a/packages/core/src/Base/Traits/Searchable.php
+++ b/packages/core/src/Base/Traits/Searchable.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace GetCandy\Base\Traits;
+
+use Laravel\Scout\Searchable as ScoutSearchable;
+
+trait Searchable
+{
+    use ScoutSearchable;
+
+    /**
+     * Define the additional fields we want to index.
+     *
+     * @var array
+     */
+    protected $additionalSearchFields = [];
+
+    /**
+     * Return our base (core) attributes we want searchable.
+     *
+     * @return array
+     */
+    public function getSearchableAttributes()
+    {
+        return [
+            'id' => $this->id,
+        ];
+    }
+
+    /**
+     * Return out base attributes we want filterable.
+     *
+     * @return array
+     */
+    public function getFilterableAttributes()
+    {
+        return [
+            'status',
+            'placed_at',
+            'created_at',
+            'total',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getObservableEvents()
+    {
+        return array_merge(parent::getObservableEvents(), [
+            'indexing',
+        ]);
+    }
+
+    /**
+     * Add an attribute into the additional searchable fields.
+     *
+     * @param string $key
+     * @param string|mixed $value
+     * @return void
+     */
+    public function addSearchableAttribute($key, $value)
+    {
+        if (!isset($this->additionalSearchFields[$key])) {
+            $this->additionalSearchFields[$key] = $value;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function toSearchableArray()
+    {
+        if (config('scout.driver') == 'mysql') {
+            return $this->only(array_keys($this->getAttributes()));
+        }
+
+        $this->fireModelEvent('indexing');
+
+        return array_merge(
+            $this->getSearchableAttributes(),
+            $this->additionalSearchFields
+        );
+    }
+}

--- a/packages/core/src/Console/Commands/MeilisearchSetup.php
+++ b/packages/core/src/Console/Commands/MeilisearchSetup.php
@@ -52,7 +52,9 @@ class MeilisearchSetup extends Command
 
         // Make sure we have the relevant indexes ready to go.
         foreach ($this->searchables as $searchable) {
-            $indexName = (new $searchable())->searchableAs();
+            $model = (new $searchable());
+
+            $indexName = $model->searchableAs();
 
             try {
                 $index = $this->engine->getIndex($indexName);
@@ -63,25 +65,17 @@ class MeilisearchSetup extends Command
                 $index = $this->engine->getIndex($indexName);
             }
 
-            $index->updateFilterableAttributes([
-                '__soft_deleted',
-            ]);
+            $this->info("Adding filterable fields to {$searchable}");
+
+            $index->updateFilterableAttributes(
+                $model->getFilterableAttributes()
+            );
+
+            $this->info("Adding sortable fields to {$searchable}");
+
+            $index->updateSortableAttributes(
+                $model->getSortableAttributes()
+            );
         }
-
-        $this->setUpOrders();
-    }
-
-    protected function setUpOrders()
-    {
-        $index = $this->engine->getIndex(
-            (new Order())->searchableAs()
-        );
-
-        $index->updateFilterableAttributes([
-            'status',
-            'placed_at',
-            'created_at',
-            'total',
-        ]);
     }
 }

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -31,6 +31,22 @@ class Collection extends BaseModel implements SpatieHasMedia
     }
 
     /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'name',
+    ];
+
+    /**
      * Define which attributes should be cast.
      *
      * @var array

--- a/packages/core/src/Models/Collection.php
+++ b/packages/core/src/Models/Collection.php
@@ -9,12 +9,12 @@ use GetCandy\Base\Traits\HasCustomerGroups;
 use GetCandy\Base\Traits\HasMedia;
 use GetCandy\Base\Traits\HasTranslations;
 use GetCandy\Base\Traits\HasUrls;
+use GetCandy\Base\Traits\Searchable;
 use GetCandy\Database\Factories\CollectionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Support\Arr;
 use Kalnoy\Nestedset\NodeTrait;
-use Laravel\Scout\Searchable;
 use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
 
 class Collection extends BaseModel implements SpatieHasMedia
@@ -79,11 +79,9 @@ class Collection extends BaseModel implements SpatieHasMedia
     }
 
     /**
-     * Returns the indexable data for the collection.
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    public function toSearchableArray()
+    public function getSearchableAttributes()
     {
         $attributes = $this->getAttributes();
 

--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -15,6 +15,26 @@ class Customer extends BaseModel
     use Searchable;
 
     /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [
+        'name',
+        'company_name',
+    ];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'name',
+        'company_name',
+    ];
+
+    /**
      * Define the guarded attributes.
      *
      * @var array

--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -4,9 +4,9 @@ namespace GetCandy\Models;
 
 use GetCandy\Base\BaseModel;
 use GetCandy\Base\Traits\HasPersonalDetails;
+use GetCandy\Base\Traits\Searchable;
 use GetCandy\Database\Factories\CustomerFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Laravel\Scout\Searchable;
 
 class Customer extends BaseModel
 {
@@ -39,16 +39,10 @@ class Customer extends BaseModel
     }
 
     /**
-     * Returns the indexable data for the customer.
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    public function toSearchableArray()
+    public function getSearchableAttributes()
     {
-        if (config('scout.driver') == 'mysql') {
-            return $this->only(array_keys($this->getAttributes()));
-        }
-
         $metaFields = config('getcandy-hub.customers.searchable_meta', []);
 
         $data = [
@@ -59,7 +53,7 @@ class Customer extends BaseModel
         ];
 
         foreach ($metaFields as $field) {
-            $data[$field] = $this->meta?->{$field};
+            $data[$field] = optional($this->meta)->{$field};
         }
 
         return $data;

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -5,9 +5,9 @@ namespace GetCandy\Models;
 use GetCandy\Base\BaseModel;
 use GetCandy\Base\Casts\Price;
 use GetCandy\Base\Casts\TaxBreakdown;
+use GetCandy\Base\Traits\Searchable;
 use GetCandy\Database\Factories\OrderFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Laravel\Scout\Searchable;
 
 class Order extends BaseModel
 {
@@ -197,20 +197,16 @@ class Order extends BaseModel
     }
 
     /**
-     * Returns the indexable data for the order.
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    public function toSearchableArray()
+    protected function getSearchableAttributes()
     {
-        if (config('scout.driver') == 'mysql') {
-            return $this->only(array_keys($this->getAttributes()));
-        }
-
         return [
             'id'        => $this->id,
             'reference' => $this->reference,
             'status'    => $this->status,
+            'placed_at' => $this->placed_at,
+            'created_at' => $this->created_at,
             'charges'   => $this->transactions->map(function ($transaction) {
                 return [
                     'reference' => $transaction->reference,

--- a/packages/core/src/Models/Order.php
+++ b/packages/core/src/Models/Order.php
@@ -15,6 +15,29 @@ class Order extends BaseModel
     use Searchable;
 
     /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [
+        '__soft_deleted',
+        'status',
+        'created_at',
+        'placed_at',
+    ];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'created_at',
+        'placed_at',
+        'total',
+    ];
+
+    /**
      * {@inheritDoc}
      */
     protected $casts = [

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -35,6 +35,32 @@ class Product extends BaseModel implements SpatieHasMedia
     use SoftDeletes;
 
     /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [
+        '__soft_deleted',
+        'skus',
+        'brand',
+        'status',
+    ];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'name',
+        'created_at',
+        'updated_at',
+        'brand',
+        'skus',
+        'status',
+    ];
+
+    /**
      * Get the name of the index associated with the model.
      *
      * @return string

--- a/packages/core/src/Models/Product.php
+++ b/packages/core/src/Models/Product.php
@@ -11,6 +11,7 @@ use GetCandy\Base\Traits\HasTags;
 use GetCandy\Base\Traits\HasTranslations;
 use GetCandy\Base\Traits\HasUrls;
 use GetCandy\Base\Traits\LogsActivity;
+use GetCandy\Base\Traits\Searchable;
 use GetCandy\Database\Factories\ProductFactory;
 use GetCandy\Jobs\Products\Associations\Associate;
 use GetCandy\Jobs\Products\Associations\Dissociate;
@@ -18,7 +19,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Arr;
-use Laravel\Scout\Searchable;
 use Spatie\MediaLibrary\HasMedia as SpatieHasMedia;
 
 class Product extends BaseModel implements SpatieHasMedia
@@ -164,16 +164,10 @@ class Product extends BaseModel implements SpatieHasMedia
     }
 
     /**
-     * Returns the indexable data for the product.
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    public function toSearchableArray()
+    public function getSearchableAttributes()
     {
-        if (config('scout.driver') == 'mysql') {
-            return $this->only(array_keys($this->getAttributes()));
-        }
-
         $attributes = $this->getAttributes();
 
         $data = Arr::except($attributes, 'attribute_data');

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -5,9 +5,9 @@ namespace GetCandy\Models;
 use GetCandy\Base\BaseModel;
 use GetCandy\Base\Traits\HasMedia;
 use GetCandy\Base\Traits\HasTranslations;
+use GetCandy\Base\Traits\Searchable;
 use GetCandy\Database\Factories\ProductOptionFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Laravel\Scout\Searchable;
 
 class ProductOption extends BaseModel
 {
@@ -60,16 +60,10 @@ class ProductOption extends BaseModel
     }
 
     /**
-     * Returns the indexable data for the product option.
-     *
-     * @return array
+     * {@inheritDoc}
      */
-    public function toSearchableArray()
+    public function getSearchableAttributes()
     {
-        if (config('scout.driver') == 'mysql') {
-            return $this->only(array_keys($this->getAttributes()));
-        }
-
         return [
             'id'      => $this->id,
             'name'    => $this->translate('name'),

--- a/packages/core/src/Models/ProductOption.php
+++ b/packages/core/src/Models/ProductOption.php
@@ -17,6 +17,22 @@ class ProductOption extends BaseModel
     use Searchable;
 
     /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'name',
+    ];
+
+    /**
      * Get the name of the index associated with the model.
      *
      * @return string

--- a/packages/core/tests/Unit/Traits/SearchableTraitTest.php
+++ b/packages/core/tests/Unit/Traits/SearchableTraitTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Traits;
+
+use GetCandy\Models\Address;
+use GetCandy\Models\Customer;
+use GetCandy\Models\Product;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Mockery;
+
+/**
+ * @group traits
+ */
+class SearchableTraitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_add_searchable_fields()
+    {
+        Event::fake();
+
+        $product = Product::factory()->create();
+
+        $product->addSearchableAttribute('foo', 'bar');
+
+        $data = $product->toSearchableArray();
+
+        $this->assertEquals($data['foo'], 'bar');
+
+        Event::assertDispatched('eloquent.indexing: '.get_class($product));
+    }
+
+    /** @test */
+    public function can_add_filterable_fields()
+    {
+        Event::fake();
+
+        $product = Product::factory()->create();
+
+        $product->addFilterableAttributes([
+            'filter_one',
+            'filter_two',
+        ]);
+
+        $data = $product->getFilterableAttributes();
+
+        $this->assertContains('filter_one', $data);
+        $this->assertContains('filter_two', $data);
+
+        Event::assertDispatched('eloquent.searchSetup: '.get_class($product));
+    }
+
+    /** @test */
+    public function can_add_sortable_fields()
+    {
+        Event::fake();
+
+        $product = Product::factory()->create();
+
+        $product->addSortableAttributes([
+            'sort_one',
+            'sort_two',
+        ]);
+
+        $data = $product->getSortableAttributes();
+
+        $this->assertContains('sort_one', $data);
+        $this->assertContains('sort_two', $data);
+
+        Event::assertDispatched('eloquent.searchSetup: '.get_class($product));
+    }
+}

--- a/packages/core/tests/Unit/Traits/SearchableTraitTest.php
+++ b/packages/core/tests/Unit/Traits/SearchableTraitTest.php
@@ -2,13 +2,10 @@
 
 namespace GetCandy\Tests\Unit\Traits;
 
-use GetCandy\Models\Address;
-use GetCandy\Models\Customer;
 use GetCandy\Models\Product;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Event;
-use Mockery;
 
 /**
  * @group traits


### PR DESCRIPTION
This PR looks to extend the search functionality to enable developers to tap into additional search, filterable and sortable attributes on the index.

This has been based on Model Observers, providing some events for them to listen to in order to extend search, usage would look as follows:

```php
<?php

namespace App\Observers;

use GetCandy\Models\Order;

class OrderObserver
{
    /**
     * Called when we're about to index the order
     **/
    public function indexing(Order $order)
    {
        $order->addSearchableAttribute(
            'custom_field',
            $order->meta->custom_field
        );
    }

    /**
     * Called when we are setting up the index via
     * php artisan getcandy:meilisearch:update
     * */
    public function searchSetup(Order $order)
    {
        $order->addFilterableAttributes([
            'custom_field'
        ]);

        $order->addSortableAttributes([
            'custom_field'
        ]);
    }
}
```

Registering the observers is the same as any other observer and allows developers to re use ones they might already have.

```php
// EventServiceProvider.php

public function boot()
{
    Order::observe(OrderObserver::class);
}
```