### PR TITLE
Fixed typo 'admihub' on Number FieldType

### DIFF
--- a/packages/core/src/FieldTypes/Number.php
+++ b/packages/core/src/FieldTypes/Number.php
@@ -67,7 +67,7 @@ class Number implements FieldType
      */
     public function getView(): string
     {
-        return 'admihub::field-types.number.view';
+        return 'adminhub::field-types.number.view';
     }
 
     /**


### PR DESCRIPTION
Found this typo because of an error I was encountering on the hub. 

Stacktrace: https://flareapp.io/share/353dVMom#F76
