### PR TITLE
Fixed another Typo in getConfig() of Number

### DIFF
--- a/packages/core/src/FieldTypes/Number.php
+++ b/packages/core/src/FieldTypes/Number.php
@@ -78,8 +78,8 @@ class Number implements FieldType
         return [
             'view'    => 'adminhub::field-types.number',
             'options' => [
-                'min' => 'numeric,min:1',
-                'max' => 'numeric,max:255',
+                'min' => 'numeric|min:1',
+                'max' => 'numeric|max:255',
             ],
         ];
     }


### PR DESCRIPTION
Got this really weird looking Error message: https://flareapp.io/share/o7AKXxxm#F56

Problem was: someone used commas instead of vertical lines to delimit the validation rules.

