### PR TITLE
Fixed translation issue in product variations

### DIFF
--- a/packages/admin/resources/views/livewire/components/product-options/option-manager.blade.php
+++ b/packages/admin/resources/views/livewire/components/product-options/option-manager.blade.php
@@ -23,7 +23,7 @@
               @foreach($option->values as $value)
                 <label class="relative block" wire:key="option_{{ $value->id }}">
                   <input type="checkbox" class="absolute mt-2 left-2 peer" wire:model.debounce.100ms="selectedValues" value="{{ $value->id }}">
-                  <span class="items-center inline-block px-2 py-1 pl-6 space-x-1 text-sm border rounded shadow-sm cursor-pointer hover:bg-gray-100 bg-gray-50 peer-checked:bg-blue-200 peer-checked:text-blue-900 peer-checked:border-blue-500">{{ $value->name->en }}</span>
+                  <span class="items-center inline-block px-2 py-1 pl-6 space-x-1 text-sm border rounded shadow-sm cursor-pointer hover:bg-gray-100 bg-gray-50 peer-checked:bg-blue-200 peer-checked:text-blue-900 peer-checked:border-blue-500">{{ $value->translate('name') }}</span>
                 </label>
               @endforeach
           </div>

--- a/packages/admin/resources/views/livewire/components/products/variants/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/products/variants/show.blade.php
@@ -6,7 +6,7 @@
       </a>
       <strong class="text-xl">
          @foreach($variant->values as $value)
-          {{ $value->name->en }} {{ !$loop->last ? '/' : null }}
+          {{ $value->translate('name') }} {{ !$loop->last ? '/' : null }}
          @endforeach
       </strong>
     </div>

--- a/packages/admin/resources/views/partials/products/editing/variants.blade.php
+++ b/packages/admin/resources/views/partials/products/editing/variants.blade.php
@@ -38,7 +38,7 @@
               <x-hub::table.row>
                 <x-hub::table.cell class="w-full">
                   @foreach($variant->values as $value)
-                    {{ $value->name->en }} {{ !$loop->last ? '/' : null }}
+                    {{ $value->translate('name') }} {{ !$loop->last ? '/' : null }}
                   @endforeach
                 </x-hub::table.cell>
                 <x-hub::table.cell>


### PR DESCRIPTION
In the Hub, when selecting an option to create product variants, and the default language is different from "en" an error is displayed.
The same error was also displayed when loading the details of the product or its variants.

This happened because in the templates there were attributes set to "en" and not to translate the values.