### PR TITLE
Feat - Disable variants hub

### DIFF
--- a/docs/src/configuration.md
+++ b/docs/src/configuration.md
@@ -4,7 +4,7 @@
 
 ## Overview
 
-Configuration for GetCandy is separated into individual files under `config/getcandy`. You can either override the different config options adhoc or you can publish all the configration options and tweak as you see fit.
+Configuration for GetCandy is separated into individual files under `config/getcandy` for core and `config/getcandy-hub` for admin hub. You can either override the different config options adhoc or you can publish all the configration options and tweak as you see fit.
 
 ```bash
 php artisan vendor:publish --tag=getcandy
@@ -56,5 +56,29 @@ Transformations for all uploaded images.
     'small' => [
         // ...
     ],
+],
+```
+
+### Products
+
+`getcandy-hub/products`
+
+```php
+'disable_variants' => false,
+'sku' => [
+    'required' => true,
+    'unique'   => true,
+],
+'gtin' => [
+    'required' => false,
+    'unique'   => false,
+],
+'mpn' => [
+    'required' => false,
+    'unique'   => false,
+],
+'ean' => [
+    'required' => false,
+    'unique'   => false,
 ],
 ```

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -32,7 +32,7 @@ php artisan getcandy:meilisearch:setup
 
 ## [Unreleased]
 
-The is a new configraton option under `getcandy-hub/products.php` to disable product variants. This is useful if your storefront will never need to generate different product options and you don't want staff members to be able to do it accidentally.
+There is a new configuration option under `getcandy-hub/products.php` to disable product variants. This is useful if your storefront will never need to generate different product options and you don't want staff members to be able to do it accidentally.
 
 ```
 'disable_variants' => false,

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -38,6 +38,8 @@ The is a new configraton option under `getcandy-hub/products.php` to disable pro
 'disable_variants' => false,
 ```
 
+If your storefront already supports variants, you do not need to change anything.
+
 ---
 
 If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's if you want to tap into the Model Observers.

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -40,6 +40,12 @@ The is a new configraton option under `getcandy-hub/products.php` to disable pro
 
 If your storefront already supports variants, you do not need to change anything.
 
+If you disable variants, the `GenerateVariants` job will now throw an exception if it's called when this setting is `true` so you will need to update any calls to this job to handle it.
+
+```php
+GetCandy\Hub\Exceptions\VariantsDisabledException
+```
+
 ---
 
 If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's if you want to tap into the Model Observers.

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -32,6 +32,14 @@ php artisan getcandy:meilisearch:setup
 
 ## [Unreleased]
 
+The is a new configraton option under `getcandy-hub/products.php` to disable product variants. This is useful if your storefront will never need to generate different product options and you don't want staff members to be able to do it accidentally.
+
+```
+'disable_variants' => false,
+```
+
+---
+
 If you are using the scout `Searchable` trait. Make sure to change this to GetCandy's if you want to tap into the Model Observers.
 
 ```php

--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+## Added
+
+- Added new config option `disable_variants` to `getcandy-hub/products.php`. This is set to `false` by default so variants remain enabled.
+
 ## Fixed
 
 - `wire:model` now correctly references the current property when editing an attribute.

--- a/packages/admin/config/products.php
+++ b/packages/admin/config/products.php
@@ -3,6 +3,17 @@
 return [
     /*
     |--------------------------------------------------------------------------
+    | Disable product variants
+    |--------------------------------------------------------------------------
+    |
+    | If your storefront doesn't support variants and you don't want staff members
+    | to be able to generate variants, you can disable the editing components here.
+    |
+    */
+    'disable_variants' => false,
+
+    /*
+    |--------------------------------------------------------------------------
     | Product identifiers
     |--------------------------------------------------------------------------
     |

--- a/packages/admin/resources/views/partials/products/editing/sections.blade.php
+++ b/packages/admin/resources/views/partials/products/editing/sections.blade.php
@@ -73,12 +73,14 @@
         ])
       </div>
 
+      @if(!$this->variantsDisabled)
       {{--
         Variants
        --}}
       <div id="variants">
         @include('adminhub::partials.products.editing.variants')
       </div>
+      @endif
 
       @if($this->getVariantsCount() <= 1)
         <div id="pricing">

--- a/packages/admin/src/Exceptions/VariantsDisabledException.php
+++ b/packages/admin/src/Exceptions/VariantsDisabledException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace GetCandy\Hub\Exceptions;
+
+use Exception;
+
+class VariantsDisabledException extends Exception
+{
+}

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -335,7 +335,7 @@ abstract class AbstractProduct extends Component
             }
 
             // We generating variants?
-            $generateVariants = (bool) count($this->optionValues);
+            $generateVariants = (bool) count($this->optionValues) && !$this->variantsDisabled;
 
             if ($generateVariants) {
                 GenerateVariants::dispatch($this->product, $this->optionValues);
@@ -467,6 +467,16 @@ abstract class AbstractProduct extends Component
     public function getExistingTagsProperty(): array
     {
         return $this->product->tags->pluck('value')->toArray();
+    }
+
+    /**
+     * Returns whether variants should be disabled.
+     *
+     * @return void
+     */
+    public function getVariantsDisabledProperty()
+    {
+        return config('getcandy-hub.products.disable_variants', false);
     }
 
     /**
@@ -767,6 +777,7 @@ abstract class AbstractProduct extends Component
             [
                 'title'      => __('adminhub::menu.product.variants'),
                 'id'         => 'variants',
+                'hidden'     => $this->variantsDisabled,
                 'has_errors' => $this->errorBag->hasAny([]),
             ],
             [

--- a/packages/admin/src/Jobs/Products/GenerateVariants.php
+++ b/packages/admin/src/Jobs/Products/GenerateVariants.php
@@ -3,6 +3,7 @@
 namespace GetCandy\Hub\Jobs\Products;
 
 use GetCandy\Hub\Exceptions\InvalidProductValuesException;
+use GetCandy\Hub\Exceptions\VariantsDisabledException;
 use GetCandy\Models\Product;
 use GetCandy\Models\ProductOptionValue;
 use GetCandy\Models\ProductVariant;
@@ -67,6 +68,12 @@ class GenerateVariants implements ShouldQueue
      */
     public function handle()
     {
+        if (config('getcandy-hub.products.disable_variants')) {
+            throw new VariantsDisabledException(
+                'Variants are not enabled, check the hub config'
+            );
+        }
+
         Validator::make([
             'optionValues' => $this->optionValues,
         ], [

--- a/packages/admin/tests/Unit/Jobs/Products/GenerateVariantsTest.php
+++ b/packages/admin/tests/Unit/Jobs/Products/GenerateVariantsTest.php
@@ -3,6 +3,7 @@
 namespace GetCandy\Hub\Tests\Unit\Jobs\Products;
 
 use GetCandy\Hub\Exceptions\InvalidProductValuesException;
+use GetCandy\Hub\Exceptions\VariantsDisabledException;
 use GetCandy\Hub\Jobs\Products\GenerateVariants;
 use GetCandy\Hub\Tests\TestCase;
 use GetCandy\Models\Product;
@@ -89,6 +90,17 @@ class GenerateVariantsTest extends TestCase
 
         $this->expectException(ValidationException::class);
         GenerateVariants::dispatchSync($product, [1, 'foo']);
+    }
+
+    /** @test */
+    public function check_variants_only_generate_when_enabled()
+    {
+        Config::set('getcandy-hub.products.disable_variants', true);
+
+        $product = Product::factory()->has(ProductVariant::factory(), 'variants')->create();
+
+        $this->expectException(VariantsDisabledException::class);
+        GenerateVariants::dispatchSync($product, [[1], [2]]);
     }
 
     /** @test */

--- a/packages/core/src/FieldTypes/Number.php
+++ b/packages/core/src/FieldTypes/Number.php
@@ -67,7 +67,7 @@ class Number implements FieldType
      */
     public function getView(): string
     {
-        return 'admihub::field-types.number.view';
+        return 'adminhub::field-types.number.view';
     }
 
     /**


### PR DESCRIPTION
This PR looks to add a new config option for the hub to disable product variants:

```
'disable_variants' => false,
```

By default variants are enabled, but setting this to `true` will hide variant generation components in the hub, remove the link from the side menu and also will not try and generate them when you save a product.

The `GenerateVariants` job will now also throw an exception if it is called and variants are disabled.

```php
GetCandy\Hub\Exceptions\VariantsDisabledException
```