### PR TITLE
Implement JsonSerializable

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - When a user logs in, the `CartSessionAuthListener` will now check for an active cart, rather than just grabbing the latest. ([#186](https://github.com/getcandy/getcandy/issues/186))
+- `Dropdown`, `ListField` and `Number` FieldTypes now implement the `JsonSerializable` interface.
 
 ## 2.0-beta10 - 2022-02-18
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - When a user logs in, the `CartSessionAuthListener` will now check for an active cart, rather than just grabbing the latest. ([#186](https://github.com/getcandy/getcandy/issues/186))
-- `Dropdown`, `ListField` and `Number` FieldTypes now implement the `JsonSerializable` interface.
+- `Dropdown`, `ListField` and `Number` field types now implement the `JsonSerializable` interface.
 
 ## 2.0-beta10 - 2022-02-18
 

--- a/packages/core/src/FieldTypes/Dropdown.php
+++ b/packages/core/src/FieldTypes/Dropdown.php
@@ -4,8 +4,9 @@ namespace GetCandy\FieldTypes;
 
 use GetCandy\Base\FieldType;
 use GetCandy\Exceptions\FieldTypeException;
+use JsonSerializable;
 
-class Dropdown implements FieldType
+class Dropdown implements FieldType, JsonSerializable
 {
     /**
      * @var string|int
@@ -20,6 +21,16 @@ class Dropdown implements FieldType
     public function __construct($value = '')
     {
         $this->setValue($value);
+    }
+
+    /**
+     * Serialize the class.
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 
     /**

--- a/packages/core/src/FieldTypes/ListField.php
+++ b/packages/core/src/FieldTypes/ListField.php
@@ -4,8 +4,9 @@ namespace GetCandy\FieldTypes;
 
 use GetCandy\Base\FieldType;
 use GetCandy\Exceptions\FieldTypeException;
+use JsonSerializable;
 
-class ListField implements FieldType
+class ListField implements FieldType, JsonSerializable
 {
     /**
      * @var string
@@ -23,6 +24,16 @@ class ListField implements FieldType
     }
 
     /**
+     * Serialize the class.
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
+    }
+
+    /**
      * Return the value of this field.
      *
      * @return array
@@ -31,6 +42,7 @@ class ListField implements FieldType
     {
         return json_decode($this->value);
     }
+
 
     /**
      * Set the value of this field.

--- a/packages/core/src/FieldTypes/Number.php
+++ b/packages/core/src/FieldTypes/Number.php
@@ -4,8 +4,9 @@ namespace GetCandy\FieldTypes;
 
 use GetCandy\Base\FieldType;
 use GetCandy\Exceptions\FieldTypeException;
+use JsonSerializable;
 
-class Number implements FieldType
+class Number implements FieldType, JsonSerializable
 {
     /**
      * @var int|float
@@ -20,6 +21,16 @@ class Number implements FieldType
     public function __construct($value = 0)
     {
         $this->setValue($value);
+    }
+
+    /**
+     * Serialize the class.
+     *
+     * @return string
+     */
+    public function jsonSerialize()
+    {
+        return $this->value;
     }
 
     /**


### PR DESCRIPTION
Some field types did not implement the `JsonSerializable` interface which could cause issues when packages like Livewire try and rehydrate components which use them. 