### PR TITLE
Fix tax reference to use "description" and not "name"

### DIFF
--- a/packages/admin/resources/views/livewire/components/orders/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/orders/show.blade.php
@@ -173,7 +173,7 @@
             @foreach($order->tax_breakdown as $tax)
               <tr>
                 <td colspan="6"></td>
-                <td class="p-2 text-sm">{{ $tax->name }}</td>
+                <td class="p-2 text-sm">{{ $tax->description }}</td>
                 <td>{{ $tax->total->formatted }}</td>
               </tr>
             @endforeach


### PR DESCRIPTION
This is a hot fix to the current order screens. I know they're being replaced, but they don't work currently.

Fixes #196 