### PR TITLE
Remove Livewire UI modal dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
         "kalnoy/nestedset": "^6.0",
         "laravel/framework": "^8.0|^9.0",
         "laravel/scout": "^9.4",
-        "livewire-ui/modal": "^1.0",
         "livewire/livewire": "^2.0",
         "php": "^8.0",
         "spatie/laravel-activitylog": "^4.4",

--- a/packages/admin/tests/TestCase.php
+++ b/packages/admin/tests/TestCase.php
@@ -30,7 +30,6 @@ class TestCase extends \Orchestra\Testbench\TestCase
             LivewireServiceProvider::class,
             AdminHubServiceProvider::class,
             ActivitylogServiceProvider::class,
-            LivewireModalServiceProvider::class,
             MediaLibraryServiceProvider::class,
             ConverterServiceProvider::class,
             NestedSetServiceProvider::class,

--- a/packages/admin/tests/TestCase.php
+++ b/packages/admin/tests/TestCase.php
@@ -8,7 +8,6 @@ use GetCandy\Hub\AdminHubServiceProvider;
 use Illuminate\Support\Facades\Config;
 use Kalnoy\Nestedset\NestedSetServiceProvider;
 use Livewire\LivewireServiceProvider;
-use LivewireUI\Modal\LivewireModalServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 


### PR DESCRIPTION
The admin package still referenced the livewire modal package in the test runner. The mono repo still had it in it's composer so it wasn't picked up. This was causing admin package tests to fail when run on their own.