### PR TITLE
Hotfix/fix missing urls on record creation

### DIFF
--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -36,6 +36,7 @@ use GetCandy\Models\Collection;
 use GetCandy\Models\Currency;
 use GetCandy\Models\Language;
 use GetCandy\Models\OrderLine;
+use GetCandy\Models\Product;
 use GetCandy\Models\Url;
 use GetCandy\Observers\AddressObserver;
 use GetCandy\Observers\CartLineObserver;
@@ -44,6 +45,7 @@ use GetCandy\Observers\CollectionObserver;
 use GetCandy\Observers\CurrencyObserver;
 use GetCandy\Observers\LanguageObserver;
 use GetCandy\Observers\OrderLineObserver;
+use GetCandy\Observers\ProductObserver;
 use GetCandy\Observers\UrlObserver;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Auth\Events\Logout;
@@ -226,6 +228,7 @@ class GetCandyServiceProvider extends ServiceProvider
         CartLine::observe(CartLineObserver::class);
         OrderLine::observe(OrderLineObserver::class);
         Address::observe(AddressObserver::class);
+        Product::observe(ProductObserver::class);
     }
 
     /**

--- a/packages/core/src/Observers/CollectionObserver.php
+++ b/packages/core/src/Observers/CollectionObserver.php
@@ -4,9 +4,28 @@ namespace GetCandy\Observers;
 
 use GetCandy\Jobs\Collections\UpdateProductPositions;
 use GetCandy\Models\Collection;
+use GetCandy\Models\Language;
+use Illuminate\Support\Str;
 
 class CollectionObserver
 {
+    /**
+     * Handle the collection "created" event.
+     *
+     * @param Collection $collection
+     * @return void
+     */
+    public function created(Collection $collection)
+    {
+        if (!$collection->urls()->count() && $language = Language::getDefault()) {
+            $collection->urls()->create([
+                'slug' => Str::slug($collection->translateAttribute('name')),
+                'default' => true,
+                'language_id' => $language->id,
+            ]);
+        }
+    }
+
     /**
      * Handle the Collection "updated" event.
      *

--- a/packages/core/src/Observers/CollectionObserver.php
+++ b/packages/core/src/Observers/CollectionObserver.php
@@ -12,12 +12,12 @@ class CollectionObserver
     /**
      * Handle the collection "created" event.
      *
-     * @param Collection $collection
+     * @param  Collection  $collection
      * @return void
      */
     public function created(Collection $collection)
     {
-        if (!$collection->urls()->count() && $language = Language::getDefault()) {
+        if (! $collection->urls()->count() && $language = Language::getDefault()) {
             $collection->urls()->create([
                 'slug' => Str::slug($collection->translateAttribute('name')),
                 'default' => true,

--- a/packages/core/src/Observers/ProductObserver.php
+++ b/packages/core/src/Observers/ProductObserver.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace GetCandy\Observers;
+
+use GetCandy\Models\Collection;
+use GetCandy\Models\Language;
+use GetCandy\Models\Product;
+use Illuminate\Support\Str;
+
+class ProductObserver
+{
+    /**
+     * Handle the collection "created" event.
+     *
+     * @param Collection $collection
+     * @return void
+     */
+    public function created(Product $product)
+    {
+        if (!$product->urls()->count() && $language = Language::getDefault()) {
+            $product->urls()->create([
+                'slug' => Str::slug($product->translateAttribute('name')),
+                'default' => true,
+                'language_id' => $language->id,
+            ]);
+        }
+    }
+}

--- a/packages/core/src/Observers/ProductObserver.php
+++ b/packages/core/src/Observers/ProductObserver.php
@@ -12,12 +12,12 @@ class ProductObserver
     /**
      * Handle the collection "created" event.
      *
-     * @param Collection $collection
+     * @param  Collection  $collection
      * @return void
      */
     public function created(Product $product)
     {
-        if (!$product->urls()->count() && $language = Language::getDefault()) {
+        if (! $product->urls()->count() && $language = Language::getDefault()) {
             $product->urls()->create([
                 'slug' => Str::slug($product->translateAttribute('name')),
                 'default' => true,

--- a/packages/core/tests/Unit/Models/ProductTest.php
+++ b/packages/core/tests/Unit/Models/ProductTest.php
@@ -5,6 +5,7 @@ namespace GetCandy\Tests\Unit\Models;
 use GetCandy\Models\Channel;
 use GetCandy\Models\Collection;
 use GetCandy\Models\CustomerGroup;
+use GetCandy\Models\Language;
 use GetCandy\Models\Product;
 use GetCandy\Models\ProductAssociation;
 use GetCandy\Models\ProductType;
@@ -19,6 +20,15 @@ use Illuminate\Support\Facades\DB;
 class ProductTest extends TestCase
 {
     use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+        ]);
+    }
 
     /** @test */
     public function can_make_a_product()

--- a/packages/core/tests/Unit/Observers/CollectionObserverTest.php
+++ b/packages/core/tests/Unit/Observers/CollectionObserverTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Observers;
+
+use GetCandy\Models\Collection;
+use GetCandy\Models\Language;
+use GetCandy\Models\Url;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+/**
+ * @group observers
+ */
+class CollectionObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function creates_default_url_when_collection_is_created()
+    {
+        $language = Language::factory()->create([
+            'default' => true,
+        ]);
+
+        $this->assertEquals(0, Url::count());
+
+        $collection = Collection::factory()->create();
+
+        $this->assertDatabaseHas((new Url)->getTable(), [
+            'language_id' => $language->id,
+            'slug' => Str::slug(
+                $collection->translateAttribute('name')
+            ),
+            'default' => true,
+        ]);
+    }
+}

--- a/packages/core/tests/Unit/Observers/ProductObserverTest.php
+++ b/packages/core/tests/Unit/Observers/ProductObserverTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Observers;
+
+use GetCandy\Models\Collection;
+use GetCandy\Models\Language;
+use GetCandy\Models\Product;
+use GetCandy\Models\Url;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+
+/**
+ * @group observers
+ */
+class ProductObserverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function creates_default_url_when_product_is_created()
+    {
+        $language = Language::factory()->create([
+            'default' => true,
+        ]);
+
+        $this->assertEquals(0, Url::count());
+
+        $product = Product::factory()->create();
+
+        $this->assertDatabaseHas((new Url)->getTable(), [
+            'language_id' => $language->id,
+            'slug' => Str::slug(
+                $product->translateAttribute('name')
+            ),
+            'default' => true,
+        ]);
+    }
+}

--- a/packages/core/tests/Unit/Observers/ProductObserverTest.php
+++ b/packages/core/tests/Unit/Observers/ProductObserverTest.php
@@ -2,7 +2,6 @@
 
 namespace GetCandy\Tests\Unit\Observers;
 
-use GetCandy\Models\Collection;
 use GetCandy\Models\Language;
 use GetCandy\Models\Product;
 use GetCandy\Models\Url;


### PR DESCRIPTION
When we create a product or collection, we're initially missing a URL for the record. This can lead to breakages on storefronts that are expecting a URL to be present.

I've added some changes via an observer so if we create a collection/product and we don't have any URL we create one based on the translated name and using the default language.

I went for the observer route instead of something like validation in the hub as creation could potentially come from anywhere, such as an import routine, so this way it's unlikely to get missed.
