### PR TITLE
Disable format conversion when generating media conversions

### DIFF
--- a/packages/core/src/Base/Traits/HasMedia.php
+++ b/packages/core/src/Base/Traits/HasMedia.php
@@ -45,6 +45,8 @@ trait HasMedia
                     $border['type']
                 );
             }
+
+            $conversion->keepOriginalImageFormat();
         });
     }
 }


### PR DESCRIPTION
When the transformations are done on the images, the format is changed to `.jpg`, which makes it difficult to use the images in the store. If it's a `.png` image you lose transparency.
I just added that line to keep the original image format.

I thought of allowing that, through the configuration, the developer could inform if he wants to do the conversion and to which formats he wanted. I use this method in other projects to generate images with various formats and be able to use the best available format according to the browser, but I don't know if this addition in core would be important.