### PR TITLE
Feature: Allow connection to be specified by config

### DIFF
--- a/packages/core/config/database.php
+++ b/packages/core/config/database.php
@@ -2,7 +2,7 @@
 
 return [
     'connection' => '',
-    
+
     'table_prefix' => 'getcandy_',
 
     /*

--- a/packages/core/config/database.php
+++ b/packages/core/config/database.php
@@ -1,6 +1,8 @@
 <?php
 
 return [
+    'connection' => '',
+    
     'table_prefix' => 'getcandy_',
 
     /*

--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -21,6 +21,10 @@ abstract class BaseModel extends Model
         parent::__construct($attributes);
 
         $this->setTable(config('getcandy.database.table_prefix').$this->getTable());
+
+        if ($connection = config('getcandy.database.connection', false)) {
+            $this->setConnection($connection);
+        }        
     }
 
     /**

--- a/packages/core/src/Base/BaseModel.php
+++ b/packages/core/src/Base/BaseModel.php
@@ -24,7 +24,7 @@ abstract class BaseModel extends Model
 
         if ($connection = config('getcandy.database.connection', false)) {
             $this->setConnection($connection);
-        }        
+        }
     }
 
     /**


### PR DESCRIPTION
Added a database config for the connection and change `BaseModel` to specify which connection to use. This allows you to use a seperate database instance for GetCandy than other packages running on the site.