### PR TITLE
Feature/cart clear

### DIFF
--- a/docs/src/getcandy/carts.md
+++ b/docs/src/getcandy/carts.md
@@ -244,6 +244,12 @@ CartSession::updateLines(collect([
 CartSession::removeLine($cartLineId);
 ```
 
+### Clear a cart
+This will remove all lines from the cart.
+```php
+CartSession::clear();
+```
+
 ### Associating a cart to a user
 You can easily associate a cart to a user.
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Added `createOrder($forget = true)` method to the `CartSession` facade.
 - Added `active` scope to the `Cart` model for carts that do not have an order associated.
 - Added ability to tap into filterable, searchable and sortable fields in Scout.
+- Added new `clear()` function to the CartManager.
 
 ### Fixed
 

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -216,7 +216,7 @@ class CartManager
     }
 
     /**
-     * Deletes all cart lines
+     * Deletes all cart lines.
      */
     public function clear()
     {

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -216,6 +216,16 @@ class CartManager
     }
 
     /**
+     * Deletes all cart lines
+     */
+    public function clear()
+    {
+        $this->cart->lines()->delete();
+
+        return $this->calculate()->getCart();
+    }
+
+    /**
      * Update cart lines.
      *
      * @param  Collection  $lines

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -539,6 +539,46 @@ class CartManagerTest extends TestCase
     }
 
     /** @test */
+    public function can_clear_a_cart()
+    {
+        $currency = Currency::factory()->create();
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $purchasableA = ProductVariant::factory()->create();
+        $purchasableB = ProductVariant::factory()->create();
+
+        PriceModel::factory()->create([
+            'price'          => 100,
+            'tier'           => 1,
+            'currency_id'    => $currency->id,
+            'priceable_type' => get_class($purchasableA),
+            'priceable_id'   => $purchasableA->id,
+        ]);
+
+        PriceModel::factory()->create([
+            'price'          => 100,
+            'tier'           => 1,
+            'currency_id'    => $currency->id,
+            'priceable_type' => get_class($purchasableB),
+            'priceable_id'   => $purchasableB->id,
+        ]);
+
+        $cart->lines()->createMany([
+            ['quantity' => 1, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableA->id],
+            ['quantity' => 2, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableB->id],
+        ]);
+
+        $this->assertCount(2, $cart->refresh()->lines);
+
+        $cart->getManager()->clear();
+
+        $this->assertCount(0, $cart->refresh()->lines);
+    }
+
+    /** @test */
     public function cannot_remove_cart_line_from_another_cart()
     {
         $currency = Currency::factory()->create();


### PR DESCRIPTION
Introduces a simple `->clear()` option to the CartManager, so you can remove all lines but keep the cart.
