### PR TITLE
Hotfix - Fix listing thumbnail

### DIFF
--- a/packages/admin/resources/views/livewire/components/products/index.blade.php
+++ b/packages/admin/resources/views/livewire/components/products/index.blade.php
@@ -143,8 +143,8 @@
         </x-hub::table.cell>
 
         <x-hub::table.cell class="w-24">
-          @if($product->thumbnail)
-            <img class="rounded shadow" src="{{ $product->thumbnail->getUrl('small') }}" />
+          @if($thumbnail = $this->getThumbnail($product))
+            <img class="rounded shadow" src="{{ $thumbnail->getUrl('small') }}" loading="lazy" />
           @else
               <x-hub::icon ref="photograph" class="w-8 h-8 mx-auto text-gray-300" />
           @endif

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductsIndex.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductsIndex.php
@@ -54,8 +54,27 @@ class ProductsIndex extends Component
     public function getProductsProperty()
     {
         return tap(Product::search($this->search)->paginate(50), function ($products) {
-            return $products->load(['thumbnail', 'productType']);
+            return $products->load(['thumbnail', 'productType', 'variants']);
         });
+    }
+
+    /**
+     * Get the listing thumbnail for a product.
+     *
+     * @param Product $product
+     * @return void
+     */
+    public function getThumbnail($product)
+    {
+        if ($product->thumbnail) {
+            return $product->thumbnail;
+        }
+
+        $variant = $product->variants->first(function ($variant) {
+            return $variant->thumbnail;
+        });
+
+        return $variant?->thumbnail;
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductsIndex.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductsIndex.php
@@ -61,7 +61,7 @@ class ProductsIndex extends Component
     /**
      * Get the listing thumbnail for a product.
      *
-     * @param Product $product
+     * @param  Product  $product
      * @return void
      */
     public function getThumbnail($product)


### PR DESCRIPTION
This is a quick fix. 

Currently, if you have a product with variants, if the product variants are the only entities that have a thumbnail and the product doesn't have one, the thumbnail is a grey icon on the listing page.

This PR makes a tweak so that we consider looking for a variant thumbnail when there isn't one present on the product itself.