### PR TITLE
Fixes issue #251: HasTranslations::translate() method ignores $locale parameter

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - `Dropdown`, `ListField` and `Number` field types now implement the `JsonSerializable` interface.
 - When deleting a record that has URLs, if it wasn't soft deleted, there is now a clean up routine to remove any existing URLs
 - When running the `getcandy:meilisearch:setup` it will now wait for a period whilst the index is created before continuing. By [@lucasvmds](https://github.com/lucasvmds)
+- `translate` method will now consider non array values passed and use the `$locale` parameter correctly [#251](https://github.com/getcandy/getcandy/issues/251). By [@armezit](https://github.com/armezit)
 
 ### Changed
 

--- a/packages/core/src/Base/Traits/HasTranslations.php
+++ b/packages/core/src/Base/Traits/HasTranslations.php
@@ -27,7 +27,9 @@ trait HasTranslations
         }
 
         $locale = $locale ?: app()->getLocale();
-        $value = is_array($values) ? Arr::get($values, $locale) : get_object_vars($values)[$locale];
+        $value = Arr::accessible($values) ?
+            Arr::get($values, $locale) :
+            get_object_vars($values)[$locale] ?? null;
 
         return $value ?: Arr::get(
             $values,

--- a/packages/core/src/Base/Traits/HasTranslations.php
+++ b/packages/core/src/Base/Traits/HasTranslations.php
@@ -26,7 +26,8 @@ trait HasTranslations
             return null;
         }
 
-        $value = Arr::get($values, $locale ?: app()->getLocale());
+        $locale = $locale ?: app()->getLocale();
+        $value = is_array($values) ? Arr::get($values, $locale) : get_object_vars($values)[$locale];
 
         return $value ?: Arr::get(
             $values,

--- a/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
+++ b/packages/core/tests/Unit/Base/Traits/HasTranslationsTest.php
@@ -8,6 +8,7 @@ use GetCandy\FieldTypes\Text;
 use GetCandy\FieldTypes\TranslatedText;
 use GetCandy\Models\AttributeGroup;
 use GetCandy\Models\Product;
+use GetCandy\Models\ProductOption;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -28,8 +29,18 @@ class HasTranslationsTest extends TestCase
             ],
         ]);
 
+        $productOption = ProductOption::factory()->create([
+            'name' => [
+                'en' => 'English Option',
+                'fr' => 'French Option',
+            ],
+        ]);
+
         $this->assertEquals('English', $attributeGroup->translate('name', 'en'));
         $this->assertEquals('French', $attributeGroup->translate('name', 'fr'));
+
+        $this->assertEquals('English Option', $productOption->translate('name', 'en'));
+        $this->assertEquals('French Option', $productOption->translate('name', 'fr'));
 
         $product = Product::factory()->create([
             'attribute_data' => [
@@ -116,6 +127,13 @@ class HasTranslationsTest extends TestCase
             ],
         ]);
 
+        $productOption = ProductOption::factory()->create([
+            'name' => [
+                'en' => 'English Option',
+                'fr' => 'French Option',
+            ],
+        ]);
+
         $product = Product::factory()->create([
             'attribute_data' => [
                 'name' => new TranslatedText(collect([
@@ -129,11 +147,13 @@ class HasTranslationsTest extends TestCase
 
         $this->assertEquals('French', $attributeGroup->translate('name'));
         $this->assertEquals('French Name', $product->translateAttribute('name'));
+        $this->assertEquals('French Option', $productOption->translate('name'));
 
         app()->setLocale('en');
 
         $this->assertEquals('English', $attributeGroup->translate('name'));
         $this->assertEquals('English Name', $product->translateAttribute('name'));
+        $this->assertEquals('English Option', $productOption->translate('name'));
     }
 
     /** @test */
@@ -143,6 +163,13 @@ class HasTranslationsTest extends TestCase
             'name' => [
                 'en' => 'English',
                 'fr' => 'French',
+            ],
+        ]);
+
+        $productOption = ProductOption::factory()->create([
+            'name' => [
+                'en' => 'English Option',
+                'fr' => 'French Option',
             ],
         ]);
 
@@ -158,6 +185,7 @@ class HasTranslationsTest extends TestCase
         app()->setLocale('dk');
 
         $this->assertEquals('English', $attributeGroup->translate('name'));
+        $this->assertEquals('English Option', $productOption->translate('name'));
         $this->assertEquals('English Name', $product->translateAttribute('name'));
     }
 


### PR DESCRIPTION
Fixes issue #251: HasTranslations::translate() method ignores $locale parameter
