### PR TITLE
Update exchange rate validation to allow full range of valid numbers

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+[Unpublished]
+
+## Fixed
+
+- Updated exchange rate validation to allow values greater than 255.
+
+
 ## 2.0-beta11 - 2022-04-04
 
 ## Added

--- a/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyCreate.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyCreate.php
@@ -39,7 +39,7 @@ class CurrencyCreate extends Component
         return [
             'currency.code'           => 'required|max:255|unique:'.$this->currency->getTable().',code',
             'currency.name'           => 'required|max:255',
-            'currency.exchange_rate'  => 'required|numeric|min:0.1|max:255',
+            'currency.exchange_rate'  => 'required|numeric|min:0.0001|max:999999.9999',
             'currency.decimal_places' => 'required|integer|max:4',
             'currency.enabled'        => 'nullable',
             'currency.default'        => 'nullable',

--- a/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Currencies/CurrencyShow.php
@@ -36,7 +36,7 @@ class CurrencyShow extends Component
         return [
             'currency.code'           => 'required|max:255|unique:'.$this->currency->getTable().',code,'.$this->currency->id,
             'currency.name'           => 'required|max:255',
-            'currency.exchange_rate'  => 'required|numeric|min:0.1',
+            'currency.exchange_rate'  => 'required|numeric|min:0.0001|max:999999.9999',
             'currency.decimal_places' => 'required|integer|max:4',
             'currency.enabled'        => 'nullable',
             'currency.default'        => 'nullable',

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Currencies/CurrencyCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Currencies/CurrencyCreateTest.php
@@ -56,16 +56,16 @@ class CurrencyCreateTest extends TestCase
         $this->actingAs($staff, 'staff');
 
         Livewire::test(CurrencyCreate::class)->call('create')
-        ->assertHasErrors([
-            'currency.name'           => 'required',
-            'currency.code'           => 'required',
-            'currency.exchange_rate'  => 'required',
-        ]);
+            ->assertHasErrors([
+                'currency.name'           => 'required',
+                'currency.code'           => 'required',
+                'currency.exchange_rate'  => 'required',
+            ]);
 
         Livewire::test(CurrencyCreate::class)
             ->set('currency.name', Str::random(260))
             ->set('currency.code', Str::random(260))
-            ->set('currency.exchange_rate', Str::random(260))
+            ->set('currency.exchange_rate', 1000000)
             ->call('create')
             ->assertHasErrors([
                 'currency.code'           => 'max',


### PR DESCRIPTION
This fixes the admin hub validation for currency exchange rates.

- [ ] Changelog entries (core and hub)
