### PR TITLE
Feat - Add multiple lines to the cart

### DIFF
--- a/docs/src/getcandy/carts.md
+++ b/docs/src/getcandy/carts.md
@@ -221,6 +221,21 @@ CartSession::manager();
 CartSession::add($purchasable, $quantity);
 ```
 
+### Add multiple lines
+
+```php
+CartSession::addLines([
+    [
+        'id' => 1,
+        'quantity' => 25,
+        'meta' => ['foo' => 'bar'],
+    ],
+    // ...
+]);
+```
+
+_Accepts a `collection` or an `array`_
+
 ### Update a single line
 
 ```php

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 
+- Added support to allow the scout driver to be defined per model.
+- Added `addLines` method to the `CartManager` that allows for multiple items to be added to the cart.
+
 ### Fixed
 
 - If a fieldtype class no longer exists, the editing pages will now remove it and prevent the associated errors.

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -201,9 +201,9 @@ class CartManager
     {
         $lines->each(function ($line) {
             $this->add(
-                $line->purchasable,
-                $line->quantity,
-                $line->meta
+                $line['purchasable'],
+                $line['quantity'],
+                $line['meta'] ?? null
             );
         });
 

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -194,12 +194,12 @@ class CartManager
     /**
      * Add cart lines.
      *
-     * @param  Collection  $lines
+     * @param  iterable  $lines
      * @return bool
      */
-    public function addLines(Collection $lines)
+    public function addLines(iterable $lines)
     {
-        $lines->each(function ($line) {
+        collect($lines)->each(function ($line) {
             $this->add(
                 $line['purchasable'],
                 $line['quantity'],

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -192,6 +192,25 @@ class CartManager
     }
 
     /**
+     * Add cart lines.
+     *
+     * @param  Collection  $lines
+     * @return bool
+     */
+    public function addLines(Collection $lines)
+    {
+        $lines->each(function ($line) {
+            $this->add(
+                $line->purchasable,
+                $line->quantity,
+                $line->meta
+            );
+        });
+
+        return true;
+    }
+
+    /**
      * Remove a cart line from the cart.
      *
      * @param  int|string  $cartLineId

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -292,6 +292,43 @@ class CartManagerTest extends TestCase
     }
 
     /** @test */
+    public function can_add_multiple_cart_lines()
+    {
+        $cart = Cart::factory()->create();
+
+        $purchasableA = ProductVariant::factory()->create();
+        $purchasableB = ProductVariant::factory()->create();
+
+        $lineA = CartLine::factory()->create(
+            ['quantity' => 1, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableA->id],
+        );
+
+        $lineB = CartLine::factory()->create(
+            ['quantity' => 2, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableB->id],
+        );
+
+        $lines = collect([$lineA, $lineB]);
+
+        $this->assertCount(0, $cart->lines);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 1,
+            'meta' => null,
+        ]);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasableB->id,
+            'quantity' => 2,
+            'meta' => null,
+        ]);
+
+        $cart->getManager()->addLines($lines);
+
+        $this->assertCount(2, $cart->refresh()->lines);
+    }
+
+    /** @test */
     public function can_update_cart_line_when_purchasable_exists()
     {
         $cart = Cart::factory()->create();

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -292,7 +292,7 @@ class CartManagerTest extends TestCase
     }
 
     /** @test */
-    public function can_add_multiple_cart_lines()
+    public function can_add_multiple_cart_lines_as_collection()
     {
         $cart = Cart::factory()->create();
 
@@ -300,15 +300,39 @@ class CartManagerTest extends TestCase
         $purchasableB = ProductVariant::factory()->create();
 
         $lines = collect([
-            [
-                'purchasable' => $purchasableA,
-                'quantity'    => 1,
-            ],
-            [
-                'purchasable' => $purchasableB,
-                'quantity'    => 2,
-            ]
+            ['purchasable' => $purchasableA, 'quantity' => 1],
+            ['purchasable' => $purchasableB, 'quantity' => 2]
         ]);
+
+        $this->assertCount(0, $cart->lines);
+
+        $cart->getManager()->addLines($lines);
+
+        $this->assertCount(2, $cart->refresh()->lines);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasableA->id,
+            'quantity' => 1,
+        ]);
+
+        $this->assertDatabaseHas((new CartLine)->getTable(), [
+            'purchasable_id' => $purchasableB->id,
+            'quantity' => 2,
+        ]);
+    }
+
+    /** @test */
+    public function can_add_multiple_cart_lines_as_array()
+    {
+        $cart = Cart::factory()->create();
+
+        $purchasableA = ProductVariant::factory()->create();
+        $purchasableB = ProductVariant::factory()->create();
+
+        $lines = [
+            ['purchasable' => $purchasableA, 'quantity' => 1],
+            ['purchasable' => $purchasableB, 'quantity' => 2]
+        ];
 
         $this->assertCount(0, $cart->lines);
 

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -299,33 +299,32 @@ class CartManagerTest extends TestCase
         $purchasableA = ProductVariant::factory()->create();
         $purchasableB = ProductVariant::factory()->create();
 
-        $lineA = CartLine::factory()->create(
-            ['quantity' => 1, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableA->id],
-        );
-
-        $lineB = CartLine::factory()->create(
-            ['quantity' => 2, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasableB->id],
-        );
-
-        $lines = collect([$lineA, $lineB]);
+        $lines = collect([
+            [
+                'purchasable' => $purchasableA,
+                'quantity'    => 1,
+            ],
+            [
+                'purchasable' => $purchasableB,
+                'quantity'    => 2,
+            ]
+        ]);
 
         $this->assertCount(0, $cart->lines);
+
+        $cart->getManager()->addLines($lines);
+
+        $this->assertCount(2, $cart->refresh()->lines);
 
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasableA->id,
             'quantity' => 1,
-            'meta' => null,
         ]);
 
         $this->assertDatabaseHas((new CartLine)->getTable(), [
             'purchasable_id' => $purchasableB->id,
             'quantity' => 2,
-            'meta' => null,
         ]);
-
-        $cart->getManager()->addLines($lines);
-
-        $this->assertCount(2, $cart->refresh()->lines);
     }
 
     /** @test */

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -301,7 +301,7 @@ class CartManagerTest extends TestCase
 
         $lines = collect([
             ['purchasable' => $purchasableA, 'quantity' => 1],
-            ['purchasable' => $purchasableB, 'quantity' => 2]
+            ['purchasable' => $purchasableB, 'quantity' => 2],
         ]);
 
         $this->assertCount(0, $cart->lines);
@@ -331,7 +331,7 @@ class CartManagerTest extends TestCase
 
         $lines = [
             ['purchasable' => $purchasableA, 'quantity' => 1],
-            ['purchasable' => $purchasableB, 'quantity' => 2]
+            ['purchasable' => $purchasableB, 'quantity' => 2],
         ];
 
         $this->assertCount(0, $cart->lines);


### PR DESCRIPTION
This PR adds a function called `addLines` that allows for bulk adding to the cart.

It doesn't add anything too exciting but it's functionality I had to create that I thought could be good in the core.
