### PR TITLE
Hotfix/only use getcandy users

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     },
     "autoload": {
         "files": [
-            "packages/admin/src/helpers.php"
+            "packages/admin/src/helpers.php",
+            "packages/core/src/helpers.php"
         ],
         "psr-4": {
             "GetCandy\\": "packages/core/src",

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -16,7 +16,10 @@
             "GetCandy\\Database\\Factories\\": "database/factories",
             "GetCandy\\Database\\Seeders\\": "database/seeders",
             "GetCandy\\Database\\State\\": "database/state"
-        }
+        },
+        "files": [
+            "src/helpers.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/packages/core/src/Listeners/CartSessionAuthListener.php
+++ b/packages/core/src/Listeners/CartSessionAuthListener.php
@@ -27,6 +27,10 @@ class CartSessionAuthListener
      */
     public function login(Login $event)
     {
+        if (! is_getcandy_user($event->user)) {
+            return;
+        }
+
         $currentCart = CartSession::current();
 
         if ($currentCart && ! $currentCart->user_id) {
@@ -55,6 +59,10 @@ class CartSessionAuthListener
      */
     public function logout(Logout $event)
     {
+        if (! is_getcandy_user($event->user)) {
+            return;
+        }
+
         CartSession::forget();
     }
 }

--- a/packages/core/src/Managers/PricingManager.php
+++ b/packages/core/src/Managers/PricingManager.php
@@ -51,7 +51,9 @@ class PricingManager implements PricingManagerInterface
 
     public function __construct()
     {
-        $this->user = Auth::user();
+        if (Auth::check() && is_getcandy_user(Auth::user())) {
+            $this->user = Auth::user();
+        }
     }
 
     /**

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -6,6 +6,7 @@ if (! function_exists('is_getcandy_user')) {
     function is_getcandy_user($user)
     {
         $traits = $traits = class_uses_recursive($user);
+
         return in_array(GetCandyUser::class, $traits);
     }
 }

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -5,7 +5,7 @@ use GetCandy\Base\Traits\GetCandyUser;
 if (! function_exists('is_getcandy_user')) {
     function is_getcandy_user($user)
     {
-        $traits = $traits = class_uses_recursive($user);
+        $traits = class_uses_recursive($user);
 
         return in_array(GetCandyUser::class, $traits);
     }

--- a/packages/core/src/helpers.php
+++ b/packages/core/src/helpers.php
@@ -1,0 +1,11 @@
+<?php
+
+use GetCandy\Base\Traits\GetCandyUser;
+
+if (! function_exists('is_getcandy_user')) {
+    function is_getcandy_user($user)
+    {
+        $traits = $traits = class_uses_recursive($user);
+        return in_array(GetCandyUser::class, $traits);
+    }
+}


### PR DESCRIPTION
Prevents edge-case scenarios whereby a non-getcandy user can be presented to the Cart or PricingManager logic.