### PR TITLE
Fix - Cart has a SavedCart relationship

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
@@ -10,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Added support to allow the scout driver to be defined per model.
+- `savedCart` relationship has been added to the `Cart` model.
 
 ### Fixed
 
@@ -184,12 +186,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## 2.0-beta2 - 2021-12-23
 
 ### Fixed
+
 - Default currency has `enabled` set to true.
 
 ### Changed
+
 - Install command no longer publishes hub assets
 
 ### Added
+
 - Added a default `CollectionGroup`.
 
 [View Changes](https://github.com/getcandy/core/compare/2.0-beta...2.0-beta2)

--- a/packages/core/src/Models/Cart.php
+++ b/packages/core/src/Models/Cart.php
@@ -163,6 +163,16 @@ class Cart extends BaseModel
     }
 
     /**
+     * Return the saved cart relationship.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasOne
+     */
+    public function savedCart()
+    {
+        return $this->hasOne(SavedCart::class);
+    }
+
+    /**
      * Return the cart manager.
      *
      * @return \GetCandy\Managers\CartManager

--- a/packages/core/tests/Unit/Models/CartTest.php
+++ b/packages/core/tests/Unit/Models/CartTest.php
@@ -9,6 +9,7 @@ use GetCandy\Models\Currency;
 use GetCandy\Models\Customer;
 use GetCandy\Models\Order;
 use GetCandy\Models\ProductVariant;
+use GetCandy\Models\SavedCart;
 use GetCandy\Tests\Stubs\User as StubUser;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -149,5 +150,26 @@ class CartTest extends TestCase
         ]);
 
         $this->assertInstanceOf(CartManager::class, $cart->getManager());
+    }
+
+    /** @test */
+    public function can_retrieve_saved_cart_relationship()
+    {
+        $currency = Currency::factory()->create();
+        $channel = Channel::factory()->create();
+
+        $cart = Cart::create([
+            'currency_id' => $currency->id,
+            'channel_id'  => $channel->id,
+            'meta'        => ['foo' => 'bar'],
+        ]);
+
+        $savedCart = SavedCart::create([
+            'name'    => 'Foo',
+            'cart_id' => $cart->id,
+        ]);
+
+        $this->assertInstanceOf(SavedCart::class, $cart->savedCart);
+        $this->assertEquals($savedCart->id, $cart->id);
     }
 }


### PR DESCRIPTION
Adds a `savedCart` relationship to the `Cart` model.

## Example

```php
// Old
auth()->user()->carts
    ->map(fn ($cart) => SavedCart::where('cart_id', $cart->id)->first() ?? null)
    ->filter();

// New
auth()->user()->carts
    ->map(fn ($cart) => $cart->savedCart)
    ->filter();
```