### PR TITLE
Hotfix - Fix meta checks when adding to cart

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
-- When adding a purchasable to the cart, a potential difference in key order for meta is taken into account.
+- When adding a purchasable to the cart, a potential difference in key order for meta is taken into account. [#271](https://github.com/getcandy/getcandy/pull/271)
 
 ### Changed
 

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+### Fixed
+
+- When adding a purchasable to the cart, a potential difference in key order for meta is taken into account.
+
+### Changed
+
 ## 2.0-beta12 - 2022-04-08
 
 ### Changed

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -169,7 +169,8 @@ class CartManager
         $existing = $this->cart->load('lines')->lines->first(function ($line) use ($purchasable, $meta) {
             return $line->purchasable_id == $purchasable->id &&
             $line->purchasable_type == get_class($purchasable) &&
-            json_encode($line->meta ?: []) == json_encode($meta ?: []);
+            array_diff((array) ($line->meta ?? []), $meta ?? []) == [] &&
+            array_diff($meta ?? [], (array) ($line->meta ?? [])) == [];
         });
 
         if ($existing) {

--- a/packages/core/tests/Unit/Managers/CartManagerTest.php
+++ b/packages/core/tests/Unit/Managers/CartManagerTest.php
@@ -356,8 +356,6 @@ class CartManagerTest extends TestCase
 
         $this->assertDatabaseCount((new CartLine)->getTable(), 1);
 
-        $this->assertDatabaseCount((new CartLine)->getTable(), 1);
-
         $cart->getManager()->add($purchasable, 1, null);
 
         $this->assertDatabaseHas((new CartLine)->getTable(), [
@@ -402,6 +400,31 @@ class CartManagerTest extends TestCase
         $cart->getManager()->add($purchasable, 1);
 
         $this->assertCount(2, $cart->refresh()->lines);
+    }
+
+    /** @test */
+    public function can_update_existing_purchasable_when_meta_key_order_differs()
+    {
+        $cart = Cart::factory()->create();
+
+        $purchasable = ProductVariant::factory()->create();
+
+        $this->assertCount(0, $cart->lines);
+
+        $cart->getManager()->add($purchasable, 1, ['alpha' => 'alpha', 'beta' => 'beta']);
+
+        $cart = $cart->refresh();
+
+        $this->assertEquals($cart->lines->first()->meta, (object) [
+            'alpha' => 'alpha',
+            'beta' => 'beta',
+        ]);
+
+        $this->assertCount(1, $cart->lines);
+
+        $cart->getManager()->add($purchasable, 1, ['beta' => 'beta', 'alpha' => 'alpha']);
+
+        $this->assertCount(1, $cart->refresh()->lines);
     }
 
     /** @test */


### PR DESCRIPTION
Currently when adding a purchasable to the cart, if the order of keys is different for the meta column, the result will be an additional cart line will be created when they are in fact still the same e.g.

```php
$cart->getManager()->add($purchasable, 1, ['alpha' => 'alpha', 'beta' => 'beta']);
```

Then calling

```php
$cart->getManager()->add($purchasable, 1, ['beta' => 'beta', 'alpha' => 'alpha']);
```

Would result in 2 cart lines being created when they are still the same. This PR looks to solve this by using `array_diff` on both the incoming and existing meta on the cart line.
