### PR TITLE
Allow number fields to be nullable

### DIFF
--- a/packages/core/src/FieldTypes/Number.php
+++ b/packages/core/src/FieldTypes/Number.php
@@ -50,7 +50,7 @@ class Number implements FieldType, JsonSerializable
      */
     public function setValue($value)
     {
-        if ((! is_numeric($value)) && $value !== '') {
+        if ((! is_numeric($value)) && $value != '') {
             throw new FieldTypeException(self::class.' value must be numeric.');
         }
 

--- a/packages/core/tests/Unit/FieldTypes/NumberTest.php
+++ b/packages/core/tests/Unit/FieldTypes/NumberTest.php
@@ -26,6 +26,30 @@ class NumberTest extends TestCase
     }
 
     /** @test */
+    public function can_set_as_empty_string()
+    {
+        $field = new Number('');
+
+        $this->assertEquals('', $field->getValue());
+
+        $field->setValue('');
+
+        $this->assertEquals('', $field->getValue());
+    }
+
+    /** @test */
+    public function can_set_as_null_value()
+    {
+        $field = new Number(null);
+
+        $this->assertEquals(null, $field->getValue());
+
+        $field->setValue(null);
+
+        $this->assertEquals(null, $field->getValue());
+    }
+
+    /** @test */
     public function check_does_not_allow_non_numerics()
     {
         $this->expectException(FieldTypeException::class);


### PR DESCRIPTION
When a number field was not required it was throwing an error when blank due to the strict blank check (the value can be null or blank).