### PR TITLE
Fixes issue with incorrect prices when zero decimal places

### DIFF
--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Incorrect price when currency has zero decimal places.
+
 ## 2.0-beta12 - 2022-04-08
 
 ### Changed

--- a/packages/core/src/DataTypes/Price.php
+++ b/packages/core/src/DataTypes/Price.php
@@ -61,8 +61,10 @@ class Price
      */
     protected function decimal()
     {
+        $decimalValue = (! $this->currency->decimal_places) ? $this->value : ($this->value / $this->currency->factor);
+
         return round(
-            ($this->value / $this->currency->factor),
+            $decimalValue,
             $this->currency->decimal_places
         );
     }

--- a/packages/core/tests/Unit/DataTypes/PriceTest.php
+++ b/packages/core/tests/Unit/DataTypes/PriceTest.php
@@ -54,6 +54,21 @@ class PriceTest extends TestCase
     }
 
     /** @test */
+    public function can_handle_no_decimal_places()
+    {
+        $currency = Currency::factory()->create([
+            'code'           => 'VND',
+            'decimal_places' => 0,
+        ]);
+
+        $dataType = new Price(100, $currency, 1);
+
+        $this->assertEquals(100, $dataType->value);
+        $this->assertEquals(100, $dataType->decimal);
+        //$this->assertEquals('£1.500', $dataType->formatted);
+    }
+
+    /** @test */
     public function can_format_numbers()
     {
         $currency = Currency::factory()->create([


### PR DESCRIPTION
Fixes #289 where currencies with zero decimal places would return incorrect price values.

A test is included to reproduce the scenario.
