### PR TITLE
Use the right driver for orders in the admin hub

### DIFF
--- a/packages/admin/src/Search/AbstractSearch.php
+++ b/packages/admin/src/Search/AbstractSearch.php
@@ -4,6 +4,7 @@ namespace GetCandy\Hub\Search;
 
 use GetCandy\Hub\Base\SearchInterface;
 use GetCandy\Hub\DataTransferObjects\Search\SearchResults;
+use Illuminate\Database\Eloquent\Model;
 
 abstract class AbstractSearch implements SearchInterface
 {
@@ -13,6 +14,22 @@ abstract class AbstractSearch implements SearchInterface
     public function __construct()
     {
         $this->driver = config('scout.driver');
+    }
+    
+    /**
+     * Return the right driver for the model
+     *
+     * @param  string  $model
+     * @return string
+     */    
+    public function getDriverForModel(string $model): string
+    {
+        $engines = config('getcandy.search.engine_map', []);
+        if (isset($engines[$model])) {
+            return $engines[$model];    
+        }
+
+        return $this->driver;
     }
 
     /**

--- a/packages/admin/src/Search/AbstractSearch.php
+++ b/packages/admin/src/Search/AbstractSearch.php
@@ -15,18 +15,18 @@ abstract class AbstractSearch implements SearchInterface
     {
         $this->driver = config('scout.driver');
     }
-    
+
     /**
-     * Return the right driver for the model
+     * Return the right driver for the model.
      *
      * @param  string  $model
      * @return string
-     */    
+     */
     public function getDriverForModel(string $model): string
     {
         $engines = config('getcandy.search.engine_map', []);
         if (isset($engines[$model])) {
-            return $engines[$model];    
+            return $engines[$model];
         }
 
         return $this->driver;

--- a/packages/admin/src/Search/OrderSearch.php
+++ b/packages/admin/src/Search/OrderSearch.php
@@ -15,7 +15,7 @@ class OrderSearch extends AbstractSearch
      */
     public function search($term, $options = [], $perPage = 25, $page = 1): SearchResults
     {
-        if ($this->driver == 'meilisearch') {
+        if ($this->getDriverForModel(Order::class) == 'meilisearch') {
             return $this->meilisearch(
                 $term,
                 $options,


### PR DESCRIPTION
PR #268 added the ability to specify the search config by mappings, but its not respected in the orders view of the admin hub.

This PR fixes that.
