### PR TITLE
Hotfix - Allow pipeline modifiers to be chained

### DIFF
--- a/packages/core/src/Base/CartLineModifier.php
+++ b/packages/core/src/Base/CartLineModifier.php
@@ -8,6 +8,36 @@ use GetCandy\Models\CartLine;
 abstract class CartLineModifier
 {
     /**
+     * Handle the process calculating pipeline
+     *
+     * @param CartLine $cartLine
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCalculating(CartLine $cartLine, $next)
+    {
+        $this->calculating($cartLine);
+
+        return $next($cartLine);
+    }
+
+    /**
+     * Handle the process calculating pipeline
+     *
+     * @param CartLine $cartLine
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCalculated(CartLine $cartLine, $next)
+    {
+        $this->calculated($cartLine);
+
+        return $next($cartLine);
+    }
+
+    /**
      * Called just before cart totals are calculated.
      *
      * @return void

--- a/packages/core/src/Base/CartLineModifier.php
+++ b/packages/core/src/Base/CartLineModifier.php
@@ -8,11 +8,10 @@ use GetCandy\Models\CartLine;
 abstract class CartLineModifier
 {
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param CartLine $cartLine
-     * @param \Closure $next
-     *
+     * @param  CartLine  $cartLine
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCalculating(CartLine $cartLine, $next)
@@ -23,11 +22,10 @@ abstract class CartLineModifier
     }
 
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param CartLine $cartLine
-     * @param \Closure $next
-     *
+     * @param  CartLine  $cartLine
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCalculated(CartLine $cartLine, $next)

--- a/packages/core/src/Base/CartModifier.php
+++ b/packages/core/src/Base/CartModifier.php
@@ -7,11 +7,10 @@ use GetCandy\Models\Cart;
 abstract class CartModifier
 {
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param CartLine $cartLine
-     * @param \Closure $next
-     *
+     * @param  CartLine  $cartLine
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCalculating(Cart $cart, $next)
@@ -22,11 +21,10 @@ abstract class CartModifier
     }
 
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param CartLine $cartLine
-     * @param \Closure $next
-     *
+     * @param  CartLine  $cartLine
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCalculated(Cart $cart, $next)

--- a/packages/core/src/Base/CartModifier.php
+++ b/packages/core/src/Base/CartModifier.php
@@ -7,6 +7,36 @@ use GetCandy\Models\Cart;
 abstract class CartModifier
 {
     /**
+     * Handle the process calculating pipeline
+     *
+     * @param CartLine $cartLine
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCalculating(Cart $cart, $next)
+    {
+        $this->calculating($cart);
+
+        return $next($cart);
+    }
+
+    /**
+     * Handle the process calculating pipeline
+     *
+     * @param CartLine $cartLine
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCalculated(Cart $cart, $next)
+    {
+        $this->calculated($cart);
+
+        return $next($cart);
+    }
+
+    /**
      * Called just before cart totals are calculated.
      *
      * @return void

--- a/packages/core/src/Base/OrderModifier.php
+++ b/packages/core/src/Base/OrderModifier.php
@@ -8,11 +8,10 @@ use GetCandy\Models\Order;
 abstract class OrderModifier
 {
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param Cart $cart
-     * @param \Closure $next
-     *
+     * @param  Cart  $cart
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCreating(Cart $cart, $next)
@@ -23,11 +22,10 @@ abstract class OrderModifier
     }
 
     /**
-     * Handle the process calculating pipeline
+     * Handle the process calculating pipeline.
      *
-     * @param Order $order
-     * @param \Closure $next
-     *
+     * @param  Order  $order
+     * @param  \Closure  $next
      * @return \Closure
      */
     public function processCreated(Order $order, $next)

--- a/packages/core/src/Base/OrderModifier.php
+++ b/packages/core/src/Base/OrderModifier.php
@@ -7,6 +7,36 @@ use GetCandy\Models\Order;
 
 abstract class OrderModifier
 {
+    /**
+     * Handle the process calculating pipeline
+     *
+     * @param Cart $cart
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCreating(Cart $cart, $next)
+    {
+        $this->creating($cart);
+
+        return $next($cart);
+    }
+
+    /**
+     * Handle the process calculating pipeline
+     *
+     * @param Order $order
+     * @param \Closure $next
+     *
+     * @return \Closure
+     */
+    public function processCreated(Order $order, $next)
+    {
+        $this->created($order);
+
+        return $next($order);
+    }
+
     public function creating(Cart $cart)
     {
         //

--- a/packages/core/src/Managers/CartLineManager.php
+++ b/packages/core/src/Managers/CartLineManager.php
@@ -32,7 +32,7 @@ class CartLineManager
                 $this->getModifiers()->toArray()
             );
 
-        $pipeline->send($this->cartLine)->via('calculating')->thenReturn();
+        $pipeline->send($this->cartLine)->via('processCalculating')->thenReturn();
 
         $line = app(CalculateLine::class)->execute(
             $this->cartLine,
@@ -41,7 +41,7 @@ class CartLineManager
             $billingAddress
         );
 
-        $pipeline->send($line)->via('calculated')->thenReturn();
+        $pipeline->send($line)->via('processCalculated')->thenReturn();
 
         return $line;
     }

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -73,7 +73,7 @@ class CartManager
                 $this->getModifiers()->toArray()
             );
 
-        $pipeline->via('calculating')->thenReturn();
+        $pipeline->via('processCalculating')->thenReturn();
 
         $lines = $this->calculateLines();
 
@@ -124,7 +124,7 @@ class CartManager
             ];
         });
 
-        $pipeline->via('calculated')->thenReturn();
+        $pipeline->via('processCalculated')->thenReturn();
 
         return $this;
     }

--- a/packages/core/tests/Unit/Base/CartLineModifiersTest.php
+++ b/packages/core/tests/Unit/Base/CartLineModifiersTest.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Base;
+
+use GetCandy\Base\CartLineModifier;
+use GetCandy\Base\CartLineModifiers;
+use GetCandy\Base\CartModifiers;
+use GetCandy\Base\Casts\Price as CastsPrice;
+use GetCandy\Base\OrderModifier;
+use GetCandy\DataTypes\Price as DataTypesPrice;
+use GetCandy\Models\Cart;
+use GetCandy\Models\CartLine;
+use GetCandy\Models\Currency;
+use GetCandy\Models\Language;
+use GetCandy\Models\Price;
+use GetCandy\Models\ProductVariant;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Pipeline\Pipeline;
+
+/**
+ * @group modifiers
+ */
+class CartLineModifiersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+
+        Currency::factory()->create([
+            'default'        => true,
+            'decimal_places' => 2,
+        ]);
+    }
+
+    /** @test */
+    public function can_add_modifiers()
+    {
+        $modifiers = app(CartLineModifiers::class);
+
+        $modifiers->add(new class extends CartLineModifier {
+            public function calculating(CartLine $cartLine)
+            {
+                echo 1;
+            }
+        });
+
+        $this->assertCount(1, $modifiers->getModifiers());
+    }
+
+    /** @test */
+    public function can_send_modifiers_through_pipeline()
+    {
+        $modifiers = app(CartLineModifiers::class);
+
+        $currency = Currency::factory()->create();
+
+        $modifiers->add(new class extends CartLineModifier {
+            public function calculating(CartLine $cartLine)
+            {
+                $cartLine->total = new DataTypesPrice(
+                    100,
+                    Currency::getDefault()
+                );
+            }
+        });
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $purchasable = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price'          => 100,
+            'tier'           => 1,
+            'currency_id'    => $currency->id,
+            'priceable_type' => get_class($purchasable),
+            'priceable_id'   => $purchasable->id,
+        ]);
+
+        $cart->lines()->createMany([
+            ['quantity' => 1, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasable->id],
+        ]);
+
+        $cartLine = $cart->lines->first();
+
+        $this->assertEquals(0, $cartLine->total?->value);
+
+        app(Pipeline::class)
+            ->through(
+                $modifiers->getModifiers()->toArray()
+            )->send($cartLine)
+            ->via('processCalculating')
+            ->thenReturn();
+
+        $this->assertEquals(100, $cartLine->total?->value);
+    }
+
+/** @test */
+    public function can_send_multiple_modifiers_through_pipeline()
+    {
+        $modifiers = app(CartLineModifiers::class);
+
+        $currency = Currency::factory()->create();
+
+        $modifiers->add(new class extends CartLineModifier {
+            public function calculating(CartLine $cartLine)
+            {
+                $cartLine->total = new DataTypesPrice(
+                    100,
+                    Currency::getDefault()
+                );
+            }
+        });
+
+        $modifiers->add(new class extends CartLineModifier {
+            public function calculating(CartLine $cartLine)
+            {
+                $cartLine->total = new DataTypesPrice(
+                    200,
+                    Currency::getDefault()
+                );
+            }
+        });
+
+        $cart = Cart::factory()->create([
+            'currency_id' => $currency->id,
+        ]);
+
+        $purchasable = ProductVariant::factory()->create();
+
+        Price::factory()->create([
+            'price'          => 100,
+            'tier'           => 1,
+            'currency_id'    => $currency->id,
+            'priceable_type' => get_class($purchasable),
+            'priceable_id'   => $purchasable->id,
+        ]);
+
+        $cart->lines()->createMany([
+            ['quantity' => 1, 'purchasable_type' => ProductVariant::class, 'purchasable_id' => $purchasable->id],
+        ]);
+
+        $cartLine = $cart->lines->first();
+
+        $this->assertEquals(0, $cartLine->total?->value);
+
+        app(Pipeline::class)
+            ->through(
+                $modifiers->getModifiers()->toArray()
+            )->send($cartLine)
+            ->via('processCalculating')
+            ->thenReturn();
+
+        $this->assertEquals(200, $cartLine->total?->value);
+    }
+}

--- a/packages/core/tests/Unit/Base/CartLineModifiersTest.php
+++ b/packages/core/tests/Unit/Base/CartLineModifiersTest.php
@@ -4,9 +4,6 @@ namespace GetCandy\Tests\Unit\Base;
 
 use GetCandy\Base\CartLineModifier;
 use GetCandy\Base\CartLineModifiers;
-use GetCandy\Base\CartModifiers;
-use GetCandy\Base\Casts\Price as CastsPrice;
-use GetCandy\Base\OrderModifier;
 use GetCandy\DataTypes\Price as DataTypesPrice;
 use GetCandy\Models\Cart;
 use GetCandy\Models\CartLine;
@@ -45,7 +42,8 @@ class CartLineModifiersTest extends TestCase
     {
         $modifiers = app(CartLineModifiers::class);
 
-        $modifiers->add(new class extends CartLineModifier {
+        $modifiers->add(new class extends CartLineModifier
+        {
             public function calculating(CartLine $cartLine)
             {
                 echo 1;
@@ -62,7 +60,8 @@ class CartLineModifiersTest extends TestCase
 
         $currency = Currency::factory()->create();
 
-        $modifiers->add(new class extends CartLineModifier {
+        $modifiers->add(new class extends CartLineModifier
+        {
             public function calculating(CartLine $cartLine)
             {
                 $cartLine->total = new DataTypesPrice(
@@ -104,14 +103,15 @@ class CartLineModifiersTest extends TestCase
         $this->assertEquals(100, $cartLine->total?->value);
     }
 
-/** @test */
+    /** @test */
     public function can_send_multiple_modifiers_through_pipeline()
     {
         $modifiers = app(CartLineModifiers::class);
 
         $currency = Currency::factory()->create();
 
-        $modifiers->add(new class extends CartLineModifier {
+        $modifiers->add(new class extends CartLineModifier
+        {
             public function calculating(CartLine $cartLine)
             {
                 $cartLine->total = new DataTypesPrice(
@@ -121,7 +121,8 @@ class CartLineModifiersTest extends TestCase
             }
         });
 
-        $modifiers->add(new class extends CartLineModifier {
+        $modifiers->add(new class extends CartLineModifier
+        {
             public function calculating(CartLine $cartLine)
             {
                 $cartLine->total = new DataTypesPrice(


### PR DESCRIPTION
Fixes #304 

---

The way modifiers work makes it difficult for them to be chained. This is due to needing to call `$next` in the modifier so it's sent through the pipeline.

The issue with that is it will rely on developers who use modifiers to implement this themselves, it will likely cause issues i.e. if it's forgotten or if developers end up passing the wrong object/value back through the pipeline 

A proposed solution is to implement a new method on each abstract modifier class called via the pipeline instead, meaning GetCandy can retain control and means any current modifiers can stay the same.

For example, on the CartLineModifier


```php
    /**
     * Handle the process calculating pipeline
     *
     * @param CartLine $cartLine
     * @param \Closure $next
     *
     * @return \Closure
     */
    public function processCalculating(CartLine $cartLine, $next)
    {
        $this->calculating($cartLine);

        return $next($cartLine);
    }
```

Which is then called in the CartLineManager like so:

```php
$pipeline->send($this->cartLine)->via('processCalculating')->thenReturn();
```