### PR TITLE
Hotfix - Adjust modifiers going through pipelines

### DIFF
--- a/docs/src/extending/cart-modifiers.md
+++ b/docs/src/extending/cart-modifiers.md
@@ -13,19 +13,22 @@ There may instances where you need to make changes to a cart or cart line, befor
 
 namespace App\Modifiers;
 
+use Closure;
 use GetCandy\Base\CartModifier;
 use GetCandy\Models\Cart;
 
 class CustomCartModifier extends CartModifier
 {
-    public function calculating(Cart $cart)
+    public function calculating(Cart $cart, Closure $next): Cart
     {
-        //
+        // ...
+        return $next($cart);
     }
 
-    public function calculated(Cart $cart)
+    public function calculated(Cart $cart, Closure $next): Cart
     {
-        //
+        // ...
+        return $next($cart);
     }
 }
 ```
@@ -35,19 +38,22 @@ class CustomCartModifier extends CartModifier
 
 namespace App\Modifiers;
 
+use Closure;
 use GetCandy\Base\CartLineModifier;
 use GetCandy\Models\CartLine;
 
 class CustomCartLineModifier extends CartLineModifier
 {
-    public function calculating(CartLine $cartLine)
+    public function calculating(CartLine $cartLine, Closure $next): CartLine
     {
-        //
+        // ...
+        return $next($cartLine);
     }
 
-    public function calculated(CartLine $cartLine)
+    public function calculated(CartLine $cartLine, Closure $next): CartLine
     {
-        //
+        // ...
+        return $next($cartLine);
     }
 }
 ```

--- a/docs/src/extending/order-modifiers.md
+++ b/docs/src/extending/order-modifiers.md
@@ -32,7 +32,6 @@ class CustomOrderModifier extends OrderModifier
     public function creating(Cart $cart, Closure $next): Cart
     {
         //...
-
         return $next($cart);
     }
 

--- a/docs/src/extending/order-modifiers.md
+++ b/docs/src/extending/order-modifiers.md
@@ -22,20 +22,24 @@ public function boot(OrderModifiers $orderModifiers)
 ```php
 namespace App\Modifiers;
 
+use Closure;
 use GetCandy\Base\OrderModifier;
 use GetCandy\Models\Cart;
 use GetCandy\Models\Order;
 
 class CustomOrderModifier extends OrderModifier
 {
-    public function creating(Cart $cart)
+    public function creating(Cart $cart, Closure $next): Cart
     {
-        //
+        //...
+
+        return $next($cart);
     }
 
-    public function created(Order $order)
+    public function created(Order $order, Closure $next): Order
     {
-        //
+        //...
+        return $next($order);
     }
 }
 

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -30,6 +30,74 @@ If you're using Meilisearch, run the following
 php artisan getcandy:meilisearch:setup
 ```
 
+## [Unreleased]
+
+### Changes to modifiers - High Impact
+
+If you're using custom modifiers, you will need to update the methods like so:
+
+CartLineModifier
+
+```php
+/**
+ * Called just before cart totals are calculated.
+ *
+ * @return CartLine
+ */
+public function calculating(CartLine $cartLine, Closure $next): CartLine
+{
+    return $next($cartLine);
+}
+
+/**
+ * Called just after cart totals are calculated.
+ *
+ * @return CartLine
+ */
+public function calculated(CartLine $cartLine, Closure $next): CartLine
+{
+    return $next($cartLine);
+}
+```
+
+CartLineModifier
+
+```php
+    /**
+ * Called just before cart totals are calculated.
+ *
+ * @return void
+ */
+public function calculating(Cart $cart, Closure $next): Cart
+{
+    return $next($cart);
+}
+
+/**
+ * Called just after cart totals are calculated.
+ *
+ * @return void
+ */
+public function calculated(Cart $cart, Closure $next): Cart
+{
+    return $next($cart);
+}
+```
+
+OrderModifier
+
+```php
+public function creating(Cart $cart, Closure $next): Cart
+{
+    return $next($cart);
+}
+
+public function created(Order $order, Closure $next): Order
+{
+    return $next($order);
+}
+```
+
 ## 2.0-beta13
 
 ### Additional Scout configuration

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -41,7 +41,7 @@ class CreateOrder
                     $this->getModifiers()->toArray()
                 );
 
-            $pipeline->via('creating')->thenReturn();
+            $cart = $pipeline->via('creating')->thenReturn();
 
             $order = Order::create([
                 'user_id'            => $cart->user_id,
@@ -147,9 +147,7 @@ class CreateOrder
 
             $cart->save();
 
-            $pipeline->send($order)->via('created')->thenReturn();
-
-            return $order;
+            return $pipeline->send($order)->via('created')->thenReturn();
         });
     }
 

--- a/packages/core/src/Base/CartLineModifier.php
+++ b/packages/core/src/Base/CartLineModifier.php
@@ -2,7 +2,7 @@
 
 namespace GetCandy\Base;
 
-use GetCandy\Models\Cart;
+use Closure;
 use GetCandy\Models\CartLine;
 
 abstract class CartLineModifier
@@ -10,20 +10,20 @@ abstract class CartLineModifier
     /**
      * Called just before cart totals are calculated.
      *
-     * @return void
+     * @return CartLine
      */
-    public function calculating(CartLine $cartLine)
+    public function calculating(CartLine $cartLine, Closure $next): CartLine
     {
-        //
+        return $next($cartLine);
     }
 
     /**
      * Called just after cart totals are calculated.
      *
-     * @return void
+     * @return CartLine
      */
-    public function calculated(CartLine $cartLine)
+    public function calculated(CartLine $cartLine, Closure $next): CartLine
     {
-        //
+        return $next($cartLine);
     }
 }

--- a/packages/core/src/Base/CartModifier.php
+++ b/packages/core/src/Base/CartModifier.php
@@ -2,6 +2,7 @@
 
 namespace GetCandy\Base;
 
+use Closure;
 use GetCandy\Models\Cart;
 
 abstract class CartModifier
@@ -11,9 +12,9 @@ abstract class CartModifier
      *
      * @return void
      */
-    public function calculating(Cart $cart)
+    public function calculating(Cart $cart, Closure $next): Cart
     {
-        //
+        return $next($cart);
     }
 
     /**
@@ -21,8 +22,8 @@ abstract class CartModifier
      *
      * @return void
      */
-    public function calculated(Cart $cart)
+    public function calculated(Cart $cart, Closure $next): Cart
     {
-        //
+        return $next($cart);
     }
 }

--- a/packages/core/src/Base/OrderModifier.php
+++ b/packages/core/src/Base/OrderModifier.php
@@ -2,18 +2,19 @@
 
 namespace GetCandy\Base;
 
+use Closure;
 use GetCandy\Models\Cart;
 use GetCandy\Models\Order;
 
 abstract class OrderModifier
 {
-    public function creating(Cart $cart)
+    public function creating(Cart $cart, Closure $next): Cart
     {
-        //
+        return $next($cart);
     }
 
-    public function created(Order $order)
+    public function created(Order $order, Closure $next): Order
     {
-        //
+        return $next($order);
     }
 }

--- a/packages/core/src/Managers/CartLineManager.php
+++ b/packages/core/src/Managers/CartLineManager.php
@@ -32,7 +32,7 @@ class CartLineManager
                 $this->getModifiers()->toArray()
             );
 
-        $pipeline->send($this->cartLine)->via('calculating')->thenReturn();
+        $this->cartLine = $pipeline->send($this->cartLine)->via('calculating')->thenReturn();
 
         $line = app(CalculateLine::class)->execute(
             $this->cartLine,
@@ -41,9 +41,7 @@ class CartLineManager
             $billingAddress
         );
 
-        $pipeline->send($line)->via('calculated')->thenReturn();
-
-        return $line;
+        return $pipeline->send($line)->via('calculated')->thenReturn();
     }
 
     /**

--- a/packages/core/src/Managers/CartManager.php
+++ b/packages/core/src/Managers/CartManager.php
@@ -73,7 +73,7 @@ class CartManager
                 $this->getModifiers()->toArray()
             );
 
-        $pipeline->via('calculating')->thenReturn();
+        $this->cart = $pipeline->via('calculating')->thenReturn();
 
         $lines = $this->calculateLines();
 
@@ -124,7 +124,7 @@ class CartManager
             ];
         });
 
-        $pipeline->via('calculated')->thenReturn();
+        $this->cart = $pipeline->via('calculated')->thenReturn();
 
         return $this;
     }

--- a/packages/core/tests/Stubs/TestCartLineModifier.php
+++ b/packages/core/tests/Stubs/TestCartLineModifier.php
@@ -12,6 +12,7 @@ class TestCartLineModifier extends CartLineModifier
     public function calculating(CartLine $cartLine, Closure $next): CartLine
     {
         $cartLine->unitPrice = new Price(1000, $cartLine->cart->currency, 1);
+
         return $next($cartLine);
     }
 }

--- a/packages/core/tests/Stubs/TestCartLineModifier.php
+++ b/packages/core/tests/Stubs/TestCartLineModifier.php
@@ -2,18 +2,16 @@
 
 namespace GetCandy\Tests\Stubs;
 
+use Closure;
 use GetCandy\Base\CartLineModifier;
 use GetCandy\DataTypes\Price;
 use GetCandy\Models\CartLine;
 
 class TestCartLineModifier extends CartLineModifier
 {
-    public function calculating(CartLine $cartLine)
+    public function calculating(CartLine $cartLine, Closure $next): CartLine
     {
         $cartLine->unitPrice = new Price(1000, $cartLine->cart->currency, 1);
-    }
-
-    public function calculated(CartLine $cartLine)
-    {
+        return $next($cartLine);
     }
 }

--- a/packages/core/tests/Stubs/TestCartModifier.php
+++ b/packages/core/tests/Stubs/TestCartModifier.php
@@ -16,6 +16,7 @@ class TestCartModifier extends CartModifier
     public function calculated(Cart $cart, Closure $next): Cart
     {
         $cart->total->value = 5000;
+
         return $next($cart);
     }
 }

--- a/packages/core/tests/Stubs/TestCartModifier.php
+++ b/packages/core/tests/Stubs/TestCartModifier.php
@@ -2,28 +2,20 @@
 
 namespace GetCandy\Tests\Stubs;
 
+use Closure;
 use GetCandy\Base\CartModifier;
 use GetCandy\Models\Cart;
 
 class TestCartModifier extends CartModifier
 {
     /**
-     * Called just before cart totals are calculated.
-     *
-     * @return void
-     */
-    public function calculating(Cart $cart)
-    {
-        // $cart->total->value = 5000;
-    }
-
-    /**
      * Called just after cart totals are calculated.
      *
      * @return void
      */
-    public function calculated(Cart $cart)
+    public function calculated(Cart $cart, Closure $next): Cart
     {
         $cart->total->value = 5000;
+        return $next($cart);
     }
 }


### PR DESCRIPTION
Fixes #304 

---

This PR looks to change the way Modifiers are defined and used throughout GetCandy. Currently, we don't enforce developers to call `$next(...)` on the modifier as they do with other pipelines such as Middleware. This change will bring this into GetCandy and should make things feel more "Laravel".

This is a breaking change so people upgrading should consult the upgrade guide to see what changes they should make to each of their custom modifiers.