### PR TITLE
fix floating point precision error in unit price calc

### DIFF
--- a/packages/core/src/Actions/Carts/CalculateLine.php
+++ b/packages/core/src/Actions/Carts/CalculateLine.php
@@ -44,13 +44,10 @@ class CalculateLine
             );
         }
 
-        $decimalString = (string) round(
-            $price->decimal / $purchasable->getUnitQuantity(),
+        $unitPrice = (int) round(
+            (($price->decimal / $purchasable->getUnitQuantity())
+                * $cart->currency->factor),
             $cart->currency->decimal_places);
-
-        $factorString = (string) $cart->currency->factor;
-
-        $unitPrice = (int) bcmul( $decimalString, $factorString);
 
         $subTotal = $unitPrice * $cartLine->quantity;
 

--- a/packages/core/src/Actions/Carts/CalculateLine.php
+++ b/packages/core/src/Actions/Carts/CalculateLine.php
@@ -44,10 +44,13 @@ class CalculateLine
             );
         }
 
-        $unitPrice = (int) (round(
+        $decimalString = (string) round(
             $price->decimal / $purchasable->getUnitQuantity(),
-            $cart->currency->decimal_places
-        ) * $cart->currency->factor);
+            $cart->currency->decimal_places);
+
+        $factorString = (string) $cart->currency->factor;
+
+        $unitPrice = (int) bcmul( $decimalString, $factorString);
 
         $subTotal = $unitPrice * $cartLine->quantity;
 

--- a/packages/core/tests/Unit/Actions/Carts/CalculateLineTest.php
+++ b/packages/core/tests/Unit/Actions/Carts/CalculateLineTest.php
@@ -319,7 +319,7 @@ class CalculateLineTest extends TestCase
         ]);
 
         Price::factory()->create([
-            'price'          => 912, //Know failing value
+            'price'          => 912, //Known failing value
             'currency_id'    => $currency->id,
             'tier'           => 1,
             'priceable_type' => get_class($purchasable),


### PR DESCRIPTION
fix for issue #325 

My apologies but I couldn't create a test for this at the moment.