### PR TITLE
Support passing an options array instead

### DIFF
--- a/packages/admin/resources/views/components/input/datepicker.blade.php
+++ b/packages/admin/resources/views/components/input/datepicker.blade.php
@@ -1,10 +1,12 @@
 <div
   x-data="{
-    value: @entangle($attributes->wire('model'))
+    value: @entangle($attributes->wire('model')),
+    init() {
+      this.$nextTick(() => {
+        flatpickr($refs.input, {{ json_encode($options) }})
+      })
+    }
   }"
-  x-init="flatpickr($refs.input, {
-    enableTime: {{ $enableTime ? 'true' : 'false' }}
-  })"
   @change="value = $event.target.value"
   class="flex relative"
 >

--- a/packages/admin/resources/views/partials/availability/channels.blade.php
+++ b/packages/admin/resources/views/partials/availability/channels.blade.php
@@ -43,7 +43,7 @@
             >
               <div class="flex">
                 <div class="w-full mr-4">
-                  <x-hub::input.datepicker id="starts_at" wire:model="availability.channels.{{ $channel->id }}.starts_at" :enable-time="true"/>
+                  <x-hub::input.datepicker id="starts_at" wire:model="availability.channels.{{ $channel->id }}.starts_at" :options="[ 'enableTime' => true ]"/>
                 </div>
                 @if($availability['channels'][$channel->id]['starts_at'])
                 <button
@@ -62,7 +62,7 @@
             >
               <div class="flex">
                 <div class="w-full mr-4">
-                  <x-hub::input.datepicker id="ends_at" wire:model="availability.channels.{{ $channel->id }}.ends_at" :enable-time="true"/>
+                  <x-hub::input.datepicker id="ends_at" wire:model="availability.channels.{{ $channel->id }}.ends_at" :options="[ 'enableTime' => true ]"/>
                 </div>
                 @if($availability['channels'][$channel->id]['ends_at'])
                 <button

--- a/packages/admin/resources/views/partials/availability/customer-groups.blade.php
+++ b/packages/admin/resources/views/partials/availability/customer-groups.blade.php
@@ -43,7 +43,7 @@
             >
               <div class="flex">
                 <div class="w-full mr-4">
-                  <x-hub::input.datepicker id="starts_at" wire:model="availability.customerGroups.{{ $group->id }}.starts_at" :enable-time="true"/>
+                  <x-hub::input.datepicker id="starts_at" wire:model="availability.customerGroups.{{ $group->id }}.starts_at" :options="[ 'enableTime' => true ]"/>
                 </div>
                 @if($availability['customerGroups'][$group->id]['starts_at'])
                 <button
@@ -62,7 +62,7 @@
             >
               <div class="flex">
                 <div class="w-full mr-4">
-                  <x-hub::input.datepicker id="ends_at" wire:model="availability.customerGroups.{{ $group->id }}.ends_at" :enable-time="true"/>
+                  <x-hub::input.datepicker id="ends_at" wire:model="availability.customerGroups.{{ $group->id }}.ends_at" :options="[ 'enableTime' => true ]"/>
                 </div>
                 @if($availability['customerGroups'][$group->id]['ends_at'])
                 <button

--- a/packages/admin/src/Views/Components/Input/Datepicker.php
+++ b/packages/admin/src/Views/Components/Input/Datepicker.php
@@ -14,21 +14,21 @@ class Datepicker extends Component
     public bool $error = false;
 
     /**
-     * Whether the datepicker should support time.
+     * Any options to pass to the datepicker
      *
-     * @var bool
+     * @var array
      */
-    public bool $enableTime = false;
+    public array $options = [];
 
     /**
      * Initialise the component.
      *
      * @param  bool  $error
      */
-    public function __construct($error = false, $enableTime = false)
+    public function __construct($error = false, array $options = [])
     {
         $this->error = $error;
-        $this->enableTime = $enableTime;
+        $this->options = $options;
     }
 
     /**

--- a/packages/admin/src/Views/Components/Input/Datepicker.php
+++ b/packages/admin/src/Views/Components/Input/Datepicker.php
@@ -14,7 +14,7 @@ class Datepicker extends Component
     public bool $error = false;
 
     /**
-     * Any options to pass to the datepicker
+     * Any options to pass to the datepicker.
      *
      * @var array
      */


### PR DESCRIPTION
This PR has a few improvements/tweaks to the Datepicker component.

1) Fix for initial value on `wire:model`.

Currently flatpickr initialises the input before Alpine has a chance to resolve it through Livewire, the result is the date is always the current day. By adding `$nextTick` we initialise flatpickr once Alpinejs has finished setting up, fixing the issue.

2) Expand on options

Currently there is no way to pass in whatever options flatpickr supports, this has been added in this PR and instances of `enable-time` have been converted.