### PR TITLE
Fix - Layout logos

### DIFF
--- a/packages/admin/resources/views/partials/navigation/side-menu.blade.php
+++ b/packages/admin/resources/views/partials/navigation/side-menu.blade.php
@@ -6,19 +6,13 @@
          }">
         <a href="{{ route('hub.index') }}"
            class="flex items-center w-full h-16 px-4">
-            <img src="https://markmead.dev/gc-logo.svg"
+            <img src="https://getcandy.io/hub/getcandy_logo.svg"
                  alt="GetCandy Logo"
                  class="w-auto h-10"
-                 x-show="showExpandedMenu && !darkMode"
+                 x-show="showExpandedMenu"
                  x-cloak />
 
-            <img src="https://markmead.dev/gc-logo-white.svg"
-                 alt="GetCandy Logo"
-                 class="w-auto h-10"
-                 x-show="showExpandedMenu && darkMode"
-                 x-cloak />
-
-            <img src="https://markmead.dev/gc-favicon.svg"
+            <img src="https://getcandy.io/assets/imgs/logos/favicon.svg"
                  alt="GetCandy Logo"
                  class="w-8 h-8 mx-auto"
                  x-show="!showExpandedMenu"


### PR DESCRIPTION
I was using my personal website to host the images while in development. There was a comment left on #334 but I have no idea what happened to it 🤯

For now, I've removed the dark mode image, I guess we need to look into how we support that with logos that aren't the GetCandy one.
