### PR TITLE
Extend settings to manage product features - Part 1

### DIFF
--- a/packages/admin/resources/lang/en/components.php
+++ b/packages/admin/resources/lang/en/components.php
@@ -179,4 +179,49 @@ return [
     'activity-log.orders.capture'                   => 'Payment of :amount on card ending :last_four',
     'activity-log.orders.authorized'                   => 'Authorized of :amount on card ending :last_four',
     'activity-log.orders.refund'                   => 'refund of :amount on card ending :last_four',
+
+    /**
+     * Product Features
+     */
+    'product.features.no_feature_value_text' => 'No feature values exist, either drag existing feature value or add new ones here.',
+
+    /**
+     * Product feature create.
+     */
+    'feature-edit.name.placeholder'     => 'e.g. Additional Details',
+    'feature-edit.create_btn'           => 'Create feature',
+    'feature-edit.update_btn'           => 'Update feature',
+    'feature-edit.non_unique_handle'    => 'This name has been already been taken',
+    /**
+     * Feature show.
+     */
+    'feature.create_group_btn'               => 'Create feature',
+    'feature.create_feature_value'           => 'Create feature value',
+    'feature.edit_group_btn'                 => 'Edit feature',
+    'feature.edit_feature.value.btn'         => 'Edit feature value',
+    'feature.delete_group_btn'               => 'Delete feature',
+    'feature.edit_title'                     => 'Edit feature',
+    'feature.create_title'                   => 'Create feature',
+    'feature.delete_title'                   => 'Delete feature',
+    'feature.delete_warning'                 => 'Removing this feature will also remove all feature values associated to it. This action cannot be reversed.',
+    'feature.group_protected'                => 'This group contains feature values required by the system so cannot be removed.',
+    'feature.no_feature values_text'         => 'No feature values exist, either drag existing feature values or add new ones here.',
+    'feature.delete_feature.value.btn'       => 'Delete feature value',
+    'feature.delete_feature.value.title'     => 'Delete Feature value',
+    'feature.delete_feature.value.warning'   => 'Are you sure you want to remove this feature value?',
+    'feature.delete_feature.value.protected' => 'You cannot delete a system feature.value.',
+    'feature.no_groups'                      => 'No features found, add your first one before you can add feature values to it.',
+    /**
+     * Feature value edit.
+     */
+    'feature.value.edit.create_title'            => 'Create feature value',
+    'feature.value.edit.update_title'            => 'Update feature value',
+    'feature.value.edit.system_locked'           => 'This feature value is required by the system so some fields are disabled.',
+    'feature.value.edit.name.placeholder'        => 'e.g. Name',
+    'feature.value.edit.required.instructions'   => 'Is this feature value required when editing/creating?',
+    'feature.value.edit.searchable.instructions' => 'Should users be able to search via this feature.value.',
+    'feature.value.edit.filterable.instructions' => 'Should users be able to filter results based on this feature.value.',
+    'feature.value.edit.validation.instructions' => 'Specify any Laravel validation rules for this input.',
+    'feature.value.edit.cancel_btn'              => 'Cancel',
+    'feature.value.edit.save_feature.value.btn'  => 'Save Feature value',
 ];

--- a/packages/admin/resources/lang/en/settings.php
+++ b/packages/admin/resources/lang/en/settings.php
@@ -102,10 +102,6 @@ return [
         'When displaying, GetCandy will swap out <code>{value}</code> for the formatted price. E.g. <code>£{value}</code>.',
         'You must always include <code>{value}</code> for this to work properly.',
     ],
-    /*
-     * Addons.
-     */
-    'addons.index.table_row_action_text' => 'View',
     /**
      * Attributes.
      */
@@ -129,4 +125,10 @@ return [
      * Activity log page.
      */
     'activity_log.index.title' => 'Activity Log',
+    /*
+     * Product Features
+     */
+    'product.features.index.title'                 => 'Features',
+    'product.features.index.create_btn'            => 'Create Feature',
+    'product.features.index.table_row_action_text' => 'Edit Feature',
 ];

--- a/packages/admin/resources/views/livewire/components/settings/product/features/feature-edit.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/product/features/feature-edit.blade.php
@@ -1,0 +1,33 @@
+<form wire:submit.prevent="create">
+  <x-hub::input.group :label="__('adminhub::inputs.name')" for="name" :error="$errors->first('productFeature.name.' . $this->defaultLanguage->code)">
+    <x-hub::translatable>
+      <x-hub::input.text
+        wire:model="productFeature.name.{{ $this->defaultLanguage->code }}"
+        :error="$errors->first('productFeature.name.' . $this->defaultLanguage->code)"
+        :placeholder="__('adminhub::components.feature-edit.name.placeholder')"
+      />
+      @foreach($this->languages->filter(fn ($lang) => !$lang->default) as $language)
+        <x-slot :name="$language['code']">
+          <x-hub::input.text
+            wire:model="productFeature.name.{{ $language->code }}"
+            :placeholder="__('adminhub::components.attribute-group-edit.name.placeholder')"
+          />
+        </x-slot>
+      @endforeach
+    </x-hub::translatable>
+  </x-hub::input.group>
+
+  @if($errors->has('productFeature.handle'))
+    <div class="mt-4">
+      <x-hub::alert level="danger">
+        {{ __('adminhub::components.attribute-group-edit.non_unique_handle') }}
+      </x-hub::alert>
+    </div>
+  @endif
+
+  <div class="mt-6">
+    <x-hub::button>
+      {{ __($productFeature->id ? 'adminhub::components.feature-edit.update_btn' : 'adminhub::components.feature-edit.create_btn') }}
+    </x-hub::button>
+  </div>
+</form>

--- a/packages/admin/resources/views/livewire/components/settings/product/features/feature-value-edit.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/product/features/feature-value-edit.blade.php
@@ -1,0 +1,25 @@
+<form wire:submit.prevent="save">
+  <x-hub::input.group :label="__('adminhub::inputs.name')" for="name" :error="$errors->first('featureValue.name.' . $this->defaultLanguage->code)">
+    <x-hub::translatable>
+      <x-hub::input.text
+              wire:model="featureValue.name.{{ $this->defaultLanguage->code }}"
+              :error="$errors->first('featureValue.name.' . $this->defaultLanguage->code)"
+              :placeholder="__('adminhub::components.feature-edit.name.placeholder')"
+      />
+      @foreach($this->languages->filter(fn ($lang) => !$lang->default) as $language)
+        <x-slot :name="$language['code']">
+          <x-hub::input.text
+                  wire:model="featureValue.name.{{ $language->code }}"
+                  :placeholder="__('adminhub::components.attribute-group-edit.name.placeholder')"
+          />
+        </x-slot>
+      @endforeach
+    </x-hub::translatable>
+  </x-hub::input.group>
+
+  <div class="mt-6">
+    <x-hub::button>
+      {{ __('adminhub::components.feature.value.edit.save_feature.value.btn') }}
+    </x-hub::button>
+  </div>
+</form>

--- a/packages/admin/resources/views/livewire/components/settings/product/features/index.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/product/features/index.blade.php
@@ -1,0 +1,232 @@
+<div class="space-y-4">
+    <header class="sm:flex sm:justify-between sm:items-center">
+        <h1 class="text-xl font-bold text-gray-900 md:text-2xl dark:text-white">
+            {{ __('adminhub::settings.product.features.index.title') }}
+        </h1>
+
+        <div class="mt-4 sm:mt-0">
+            <x-hub::button wire:click.prevent="$set('showFeatureCreate', true)">
+                {{ __('adminhub::settings.product.features.index.create_btn') }}
+            </x-hub::button>
+        </div>
+    </header>
+
+    <div wire:sort
+         sort.options='{group: "groups", method: "sortGroups"}'
+         class="space-y-2">
+        @forelse($sortedProductFeatures as $feature)
+            <div wire:key="group_{{ $feature->id }}"
+                 x-data="{ expanded: false }"
+                 sort.item="groups"
+                 sort.id="{{ $feature->id }}">
+                <div class="flex items-center">
+                    <div wire:loading
+                         wire:target="sort">
+                        <x-hub::icon ref="refresh"
+                                     style="solid"
+                                     class="w-5 mr-2 text-gray-300 rotate-180 animate-spin" />
+                    </div>
+
+                    <div wire:loading.remove
+                         wire:target="sort">
+                        <div sort.handle
+                             class="cursor-grab">
+                            <x-hub::icon ref="selector"
+                                         style="solid"
+                                         class="mr-2 text-gray-400 hover:text-gray-700" />
+                        </div>
+                    </div>
+
+                    <div
+                            class="flex items-center justify-between w-full p-3 text-sm bg-white border border-transparent rounded shadow-sm sort-item-element hover:border-gray-300">
+                        <div class="flex items-center justify-between expand">
+                            {{ $feature->translate('name') }}
+                        </div>
+                        <div class="flex">
+                            @if ($feature->values->count())
+                                <button @click="expanded = !expanded">
+                                    <div class="transition-transform"
+                                         :class="{
+                                             '-rotate-90 ': expanded
+                                         }">
+                                        <x-hub::icon ref="chevron-left"
+                                                     style="solid" />
+                                    </div>
+                                </button>
+                            @endif
+                            <x-hub::dropdown minimal>
+                                <x-slot name="options">
+                                    <x-hub::dropdown.button wire:click="$set('editFeatureId', {{ $feature->id }})"
+                                                            class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50">
+                                        {{ __('adminhub::components.feature.edit_group_btn') }}
+                                    </x-hub::dropdown.button>
+
+                                    <x-hub::dropdown.button wire:click="$set('valueCreateFeatureId', {{ $feature->id }})"
+                                                            class="flex items-center justify-between px-4 py-2 text-sm border-b hover:bg-gray-50">
+                                        {{ __('adminhub::components.feature.create_feature_value') }}
+                                    </x-hub::dropdown.button>
+
+                                    <x-hub::dropdown.button wire:click="$set('deleteFeatureId', {{ $feature->id }})"
+                                                            class="flex items-center justify-between px-4 py-2 text-sm border-b hover:bg-gray-50">
+                                        <span
+                                                class="text-red-500">{{ __('adminhub::components.feature.delete_group_btn') }}</span>
+                                    </x-hub::dropdown.button>
+                                </x-slot>
+                            </x-hub::dropdown>
+                        </div>
+                    </div>
+                </div>
+                <div class="py-4 pl-2 pr-4 mt-2 space-y-2 bg-black border-l rounded bg-opacity-5 ml-7"
+                     @if ($feature->values->count()) x-show="expanded" @endif>
+                    <div class="space-y-2"
+                         wire:sort
+                         sort.options='{group: "values", method: "sortFeatureValues", owner: {{ $feature->id }}}'
+                         x-show="expanded">
+                        @foreach ($feature->values as $featureValue)
+                            <div class="flex items-center justify-between w-full p-3 text-sm bg-white border border-transparent rounded shadow-sm sort-item-element hover:border-gray-300"
+                                 wire:key="attribute_{{ $featureValue->id }}"
+                                 sort.item="values"
+                                 sort.parent="{{ $feature->id }}"
+                                 sort.id="{{ $featureValue->id }}">
+                                <div sort.handle
+                                     class="cursor-grab">
+                                    <x-hub::icon ref="selector"
+                                                 style="solid"
+                                                 class="mr-2 text-gray-400 hover:text-gray-700" />
+                                </div>
+                                <span class="truncate grow">{{ $featureValue->translate('name') }}</span>
+                                <div class="mr-4 text-xs text-gray-500">
+                                    {{ class_basename($featureValue->type) }}
+                                </div>
+                                <div>
+                                    <x-hub::dropdown minimal>
+                                        <x-slot name="options">
+                                            <x-hub::dropdown.button type="button"
+                                                                    wire:click="$set('editFeatureValueId', {{ $featureValue->id }})"
+                                                                    class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50">
+                                                {{ __('adminhub::components.feature.edit_feature.value.btn') }}
+                                                <x-hub::icon ref="pencil"
+                                                             style="solid"
+                                                             class="w-4" />
+                                            </x-hub::dropdown.button>
+
+                                            <x-hub::dropdown.button wire:click="$set('deleteFeatureValueId', {{ $featureValue->id }})"
+                                                                    class="flex items-center justify-between px-4 py-2 text-sm border-b hover:bg-gray-50">
+                                                <span
+                                                        class="text-red-500">{{ __('adminhub::components.feature.delete_feature.value.btn') }}</span>
+                                            </x-hub::dropdown.button>
+                                        </x-slot>
+                                    </x-hub::dropdown>
+                                </div>
+                            </div>
+                        @endforeach
+                    </div>
+                    @if (!$feature->values->count())
+                        <span class="mx-4 text-sm text-gray-500">
+                            {{ __('adminhub::components.product.features.no_feature_value_text') }}
+                        </span>
+                    @endif
+                </div>
+            </div>
+        @empty
+            <div class="w-full text-center text-gray-500">
+                {{ __('adminhub::components.feature.no_groups') }}
+            </div>
+        @endforelse
+    </div>
+
+    <x-hub::modal.dialog wire:model="showFeatureCreate">
+        <x-slot name="title">{{ __('adminhub::components.feature.create_title') }}</x-slot>
+        <x-slot name="content">
+            @livewire('hub.components.settings.product.feature-edit')
+        </x-slot>
+        <x-slot name="footer"></x-slot>
+    </x-hub::modal.dialog>
+
+    @if ($this->featureToEdit)
+        <x-hub::modal.dialog wire:model="editFeatureId">
+            <x-slot name="title">{{ __('adminhub::components.feature.edit_title') }}</x-slot>
+            <x-slot name="content">
+                @livewire('hub.components.settings.product.feature-edit', [
+                    'productFeature' => $this->featureToEdit,
+                ])
+            </x-slot>
+            <x-slot name="footer"></x-slot>
+        </x-hub::modal.dialog>
+    @endif
+
+    @if ($this->featureToDelete)
+        <x-hub::modal.dialog wire:model="deleteFeatureId">
+            <x-slot name="title">{{ __('adminhub::components.feature.delete_title') }}</x-slot>
+            <x-slot name="content">
+                <x-hub::alert level="danger">
+                    {{ __('adminhub::components.feature.delete_warning') }}
+                </x-hub::alert>
+            </x-slot>
+            <x-slot name="footer">
+                <div class="flex justify-between">
+                    <x-hub::button theme="gray"
+                                   wire:click="$set('deleteFeatureId', null)"
+                                   type="button">
+                        {{ __('adminhub::global.cancel') }}
+                    </x-hub::button>
+                    <x-hub::button theme="danger"
+                                   type="button"
+                                   wire:click="deleteFeature">
+                        {{ __('adminhub::global.delete') }}
+                    </x-hub::button>
+                </div>
+            </x-slot>
+        </x-hub::modal.dialog>
+    @endif
+
+    @if ($this->featureValueToDelete)
+        <x-hub::modal.dialog wire:model="deleteFeatureValueId">
+            <x-slot name="title">{{ __('adminhub::components.feature.delete_feature.value.title') }}</x-slot>
+            <x-slot name="content">
+                <x-hub::alert level="danger">
+                    {{ __('adminhub::components.feature.delete_feature.value.warning') }}
+                </x-hub::alert>
+            </x-slot>
+            <x-slot name="footer">
+                <div class="flex justify-between">
+                    <x-hub::button theme="gray"
+                                   wire:click="$set('deleteFeatureValueId', null)"
+                                   type="button">
+                        {{ __('adminhub::global.cancel') }}
+                    </x-hub::button>
+                    @if (!$this->featureValueToDelete->system)
+                        <x-hub::button theme="danger"
+                                       type="button"
+                                       wire:click="deleteFeatureValue">
+                            {{ __('adminhub::global.delete') }}
+                        </x-hub::button>
+                    @endif
+                </div>
+            </x-slot>
+        </x-hub::modal.dialog>
+    @endif
+
+    @if ($this->valueCreateFeature)
+        <x-hub::modal.dialog wire:model="valueCreateFeatureId">
+            <x-slot name="title">{{ __('adminhub::components.feature.value.edit.create_title') }}</x-slot>
+            <x-slot name="content">
+                @livewire('hub.components.settings.product.feature-value-edit', [
+                    'feature' => $this->valueCreateFeature,
+                ])
+            </x-slot>
+            <x-slot name="footer"></x-slot>
+        </x-hub::modal.dialog>
+    @endif
+    @if ($this->featureValueToEdit)
+        <x-hub::modal.dialog wire:model="editFeatureValueId">
+            <x-slot name="title">{{ __('adminhub::components.feature.value.edit.update_title') }}</x-slot>
+            <x-slot name="content">
+                @livewire('hub.components.settings.product.feature-value-edit', [
+                    'featureValue' => $this->featureValueToEdit,
+                ])
+            </x-slot>
+            <x-slot name="footer"></x-slot>
+        </x-hub::modal.dialog>
+    @endif
+</div>

--- a/packages/admin/resources/views/livewire/pages/settings/product/features/index.blade.php
+++ b/packages/admin/resources/views/livewire/pages/settings/product/features/index.blade.php
@@ -1,0 +1,3 @@
+<div>
+  @livewire('hub.components.settings.product.features.index')
+</div>

--- a/packages/admin/routes/includes/settings.php
+++ b/packages/admin/routes/includes/settings.php
@@ -1,5 +1,6 @@
 <?php
 
+use GetCandy\Hub\Http\Livewire\Components\Products\ProductTypes\ProductTypesIndex;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\ActivityLog\ActivityLogIndex;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Addons\AddonShow;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Addons\AddonsIndex;
@@ -14,6 +15,8 @@ use GetCandy\Hub\Http\Livewire\Pages\Settings\Currencies\CurrencyShow;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Languages\LanguageCreate;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Languages\LanguageShow;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Languages\LanguagesIndex;
+use GetCandy\Hub\Http\Livewire\Pages\Settings\Product\Features\FeaturesIndex;
+use GetCandy\Hub\Http\Livewire\Pages\Settings\Product\Options\OptionsIndex;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Staff\StaffCreate;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Staff\StaffIndex;
 use GetCandy\Hub\Http\Livewire\Pages\Settings\Staff\StaffShow;
@@ -105,4 +108,14 @@ Route::group([
     Route::get('/', TagsIndex::class)->name('hub.tags.index');
     // Route::get('channels/create', ChannelCreate::class)->name('hub.channels.create');
     Route::get('tags/{tag}', TagShow::class)->name('hub.tags.show');
+});
+
+/**
+ * Product features routes.
+ */
+Route::group([
+    'middleware' => 'can:settings:core',
+    'prefix'     => 'product',
+], function () {
+    Route::get('features', FeaturesIndex::class)->name('hub.product.features.index');
 });

--- a/packages/admin/src/AdminHubServiceProvider.php
+++ b/packages/admin/src/AdminHubServiceProvider.php
@@ -56,6 +56,9 @@ use GetCandy\Hub\Http\Livewire\Components\Settings\Currencies\CurrencyShow;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Languages\LanguageCreate;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Languages\LanguageShow;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Languages\LanguagesIndex;
+use GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features\FeatureEdit;
+use GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features\FeaturesIndex;
+use GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features\FeatureValueEdit;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Staff\StaffCreate;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Staff\StaffIndex;
 use GetCandy\Hub\Http\Livewire\Components\Settings\Staff\StaffShow;
@@ -69,7 +72,6 @@ use GetCandy\Hub\Menu\MenuRegistry;
 use GetCandy\Hub\Menu\OrderActionsMenu;
 use GetCandy\Hub\Menu\SettingsMenu;
 use GetCandy\Hub\Menu\SidebarMenu;
-use GetCandy\Hub\Menu\SlotRegistry;
 use GetCandy\Hub\Tables\Orders;
 use Illuminate\Routing\Events\RouteMatched;
 use Illuminate\Support\Facades\Auth;
@@ -334,6 +336,11 @@ class AdminHubServiceProvider extends ServiceProvider
         // Addons
         Livewire::component('hub.components.settings.addons.index', AddonsIndex::class);
         Livewire::component('hub.components.settings.addons.show', AddonShow::class);
+
+        // Product Feature
+        Livewire::component('hub.components.settings.product.features.index', FeaturesIndex::class);
+        Livewire::component('hub.components.settings.product.feature-edit', FeatureEdit::class);
+        Livewire::component('hub.components.settings.product.feature-value-edit', FeatureValueEdit::class);
     }
 
     /**

--- a/packages/admin/src/Facades/Menu.php
+++ b/packages/admin/src/Facades/Menu.php
@@ -3,8 +3,14 @@
 namespace GetCandy\Hub\Facades;
 
 use GetCandy\Hub\Menu\MenuRegistry;
+use GetCandy\Hub\Menu\MenuSlot;
 use Illuminate\Support\Facades\Facade;
 
+/**
+ * @method static MenuSlot slot(string $handle)
+ *
+ * @see \GetCandy\Hub\Menu\MenuRegistry
+ */
 class Menu extends Facade
 {
     /**

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureEdit.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features;
+
+use GetCandy\Hub\Http\Livewire\Traits\Notifies;
+use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
+use GetCandy\Models\ProductFeature;
+use Illuminate\Support\Str;
+use Livewire\Component;
+
+class FeatureEdit extends Component
+{
+    use WithLanguages;
+    use Notifies;
+
+    /**
+     * The feature to edit.
+     *
+     * @var \GetCandy\Models\ProductFeature
+     */
+    public ?ProductFeature $productFeature = null;
+
+    /**
+     * Return the validation rules.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = [];
+        foreach ($this->languages as $language) {
+            $rules["productFeature.name.{$language->code}"] = ($language->default ? 'required' : 'nullable').'|max:255';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function mount()
+    {
+        $this->productFeature = $this->productFeature ?: new ProductFeature();
+    }
+
+    public function create()
+    {
+        $this->validate();
+
+        $handle = Str::handle("{$this->productFeature->translate('name')}");
+        $this->productFeature->handle = $handle;
+
+        $this->validate([
+            'productFeature.handle' => 'unique:'.get_class($this->productFeature).',handle',
+        ]);
+
+        if ($this->productFeature->id) {
+            $this->productFeature->save();
+            $this->emit('feature-edit.updated', $this->productFeature->id);
+            $this->notify(
+                __('adminhub::notifications.attribute-groups.updated')
+            );
+
+            return;
+        }
+
+        $this->productFeature->position = ProductFeature::count() + 1;
+        $this->productFeature->handle = $handle;
+        $this->productFeature->save();
+
+        $this->emit('feature-edit.created', $this->productFeature->id);
+
+        $this->productFeature = new ProductFeature();
+
+        $this->notify(
+            __('adminhub::notifications.attribute-groups.created')
+        );
+    }
+
+    /**
+     * Render the livewire component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('adminhub::livewire.components.settings.product.features.feature-edit')
+            ->layout('adminhub::layouts.base');
+    }
+}

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureValueEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureValueEdit.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features;
+
+use GetCandy\Hub\Http\Livewire\Traits\Notifies;
+use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
+use GetCandy\Models\ProductFeature;
+use GetCandy\Models\ProductFeatureValue;
+use Livewire\Component;
+
+class FeatureValueEdit extends Component
+{
+    use WithLanguages;
+    use Notifies;
+
+    /**
+     * The feature instance.
+     *
+     * @var \GetCandy\Models\ProductFeature
+     */
+    public ?ProductFeature $feature = null;
+
+    /**
+     * The feature value instance.
+     *
+     * @var \GetCandy\Models\ProductFeatureValue
+     */
+    public ?ProductFeatureValue $featureValue = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function mount()
+    {
+        $this->featureValue = $this->featureValue ?: new ProductFeatureValue;
+
+        if ($this->featureValue->id) {
+            $this->feature = $this->featureValue->feature;
+        }
+    }
+
+    /**
+     * Return the validation rules.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $rules = [];
+        foreach ($this->languages as $language) {
+            $rules["featureValue.name.{$language->code}"] = ($language->default ? 'required' : 'nullable').'|max:255';
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Save the featureValue.
+     *
+     * @return void
+     */
+    public function save()
+    {
+        $this->validate();
+
+        if (! $this->featureValue->id) {
+
+            $this->featureValue->position = ProductFeatureValue::whereProductFeatureId(
+                $this->feature->id
+            )->count() + 1;
+
+            // @todo Not sure why this is not working here?
+            // $this->featureValue->increment('position');
+
+            $this->featureValue->feature()->associate($this->feature);
+            $this->featureValue->save();
+            $this->notify(
+                __('adminhub::notifications.attribute-edit.created')
+            );
+            $this->emit('feature-value-edit.created', $this->featureValue->id);
+
+            return;
+        }
+
+        $this->featureValue->save();
+
+        $this->notify(
+            __('adminhub::notifications.attribute-edit.updated')
+        );
+        $this->emit('feature-value-edit.updated', $this->featureValue->id);
+    }
+
+    /**
+     * Render the livewire component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('adminhub::livewire.components.settings.product.features.feature-value-edit')
+            ->layout('adminhub::layouts.base');
+    }
+}

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureValueEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeatureValueEdit.php
@@ -72,7 +72,7 @@ class FeatureValueEdit extends Component
             // @todo Not sure why this is not working here?
             // $this->featureValue->increment('position');
 
-            $this->featureValue->feature()->associate($this->feature);
+            $this->featureValue->productFeature()->associate($this->feature);
             $this->featureValue->save();
             $this->notify(
                 __('adminhub::notifications.attribute-edit.created')

--- a/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeaturesIndex.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Product/Features/FeaturesIndex.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace GetCandy\Hub\Http\Livewire\Components\Settings\Product\Features;
+
+use GetCandy\Facades\AttributeManifest;
+use \GetCandy\Hub\Http\Livewire\Traits\Notifies;
+use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
+use GetCandy\Models\Attribute;
+use GetCandy\Models\ProductFeature;
+use GetCandy\Models\ProductFeatureValue;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Livewire\Component;
+
+class FeaturesIndex extends Component
+{
+    use Notifies;
+    use WithLanguages;
+
+    /**
+     * The type property.
+     *
+     * @var string
+     */
+    public $type;
+
+    /**
+     * The sorted product features.
+     *
+     * @var Collection
+     */
+    public Collection $sortedProductFeatures;
+
+    /**
+     * Whether we should show the panel to create a new group.
+     *
+     * @var bool
+     */
+    public $showFeatureCreate = false;
+
+    /**
+     * The feature id to use for creating an attribute.
+     *
+     * @var int|null
+     */
+    public $valueCreateFeatureId = null;
+
+    /**
+     * The id of the feature to edit.
+     *
+     * @var int|null
+     */
+    public $editFeatureId;
+
+    /**
+     * The id of the feature to delete.
+     *
+     * @var int|null
+     */
+    public $deleteFeatureId;
+
+    /**
+     * The id of the attribute to edit.
+     *
+     * @var int|null
+     */
+    public $editFeatureValueId = null;
+
+    /**
+     * The ID of the attribute we want to delete.
+     *
+     * @var int|null
+     */
+    public $deleteFeatureValueId = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected $listeners = [
+        'feature-edit.created'       => 'refreshGroups',
+        'feature-edit.updated'       => 'resetGroupEdit',
+        'feature-value-edit.created' => 'resetFeatureValueEdit',
+        'feature-value-edit.updated' => 'resetFeatureValueEdit',
+        'feature-value-edit.closed'  => 'resetFeatureValueEdit',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    public function mount()
+    {
+        $this->sortedProductFeatures = $this->productFeatures;
+    }
+
+    /**
+     * Return the product features
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getProductFeaturesProperty()
+    {
+        return ProductFeature::orderBy('position')->get();
+    }
+
+    /**
+     * Return the feature to be used when creating an attribute.
+     *
+     * @return \GetCandy\Models\ProductFeature
+     */
+    public function getValueCreateFeatureProperty()
+    {
+        return ProductFeature::find($this->valueCreateFeatureId);
+    }
+
+    /**
+     * Sort the features.
+     *
+     * @param  array  $groups
+     * @return void
+     */
+    public function sortGroups($groups)
+    {
+        DB::transaction(function () use ($groups) {
+            $this->sortedProductFeatures = $this->productFeatures->map(function ($group) use ($groups) {
+                $updatedOrder = collect($groups['items'])->first(function ($updated) use ($group) {
+                    return $updated['id'] == $group->id;
+                });
+                $group->position = $updatedOrder['order'];
+                $group->save();
+
+                return $group;
+            })->sortBy('position');
+        });
+        $this->notify(
+            __('adminhub::notifications.attribute-groups.reordered')
+        );
+    }
+
+    /**
+     * Sort the feature values.
+     *
+     * @param  array  $featureValues
+     * @return void
+     */
+    public function sortFeatureValues(array $featureValues)
+    {
+        DB::transaction(function () use ($featureValues) {
+            foreach ($featureValues['items'] as $item) {
+                ProductFeatureValue::whereId($item['id'])->update([
+                    'position'           => $item['order'],
+                    'product_feature_id' => $item['parent'],
+                ]);
+            }
+        });
+
+        $this->refreshGroups();
+
+        $this->notify(
+            __('adminhub::notifications.attributes.reordered')
+        );
+    }
+
+    /**
+     * Refresh the features.
+     *
+     * @return void
+     */
+    public function refreshGroups()
+    {
+        $this->sortedProductFeatures = ProductFeature::orderBy('position')->get();
+
+        $this->showFeatureCreate = false;
+    }
+
+    /**
+     * Return the computed property for the feature to edit.
+     *
+     * @return \GetCandy\Models\ProductFeature|null
+     */
+    public function getFeatureToEditProperty()
+    {
+        return ProductFeature::find($this->editFeatureId);
+    }
+
+    /**
+     * Return the feature marked for deletion.
+     *
+     * @return \GetCandy\Models\ProductFeature|null
+     */
+    public function getFeatureToDeleteProperty(): ?ProductFeature
+    {
+        return ProductFeature::find($this->deleteFeatureId);
+    }
+
+    /**
+     * Return the feature value to edit.
+     *
+     * @return \GetCandy\Models\Attribute
+     */
+    public function getFeatureValueToEditProperty()
+    {
+        return ProductFeatureValue::find($this->editFeatureValueId);
+    }
+
+    /**
+     * Return the feature value to delete.
+     *
+     * @return \GetCandy\Models\ProductFeatureValue|null
+     */
+    public function getFeatureValueToDeleteProperty(): ?ProductFeatureValue
+    {
+        return ProductFeatureValue::find($this->deleteFeatureValueId);
+    }
+
+    /**
+     * Reset the group editing state.
+     *
+     * @return void
+     */
+    public function resetGroupEdit()
+    {
+        $this->editFeatureId = null;
+    }
+
+    /**
+     * Reset the feature value edit state.
+     *
+     * @return void
+     */
+    public function resetFeatureValueEdit()
+    {
+        $this->featureValueToDelete = null;
+        $this->valueCreateFeatureId = null;
+        $this->editFeatureValueId = null;
+        $this->refreshGroups();
+    }
+
+    /**
+     * Delete the feature value.
+     *
+     * @return void
+     */
+    public function deleteFeatureValue()
+    {
+        DB::transaction(function () {
+            $this->featureValueToDelete->delete();
+        });
+
+        $this->notify(
+            __('adminhub::notifications.attributes.deleted')
+        );
+
+        $this->resetFeatureValueEdit();
+    }
+
+    /**
+     * Render the livewire component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('adminhub::livewire.components.settings.product.features.index')
+            ->layout('adminhub::layouts.base');
+    }
+}

--- a/packages/admin/src/Http/Livewire/Pages/Settings/Product/Features/FeaturesIndex.php
+++ b/packages/admin/src/Http/Livewire/Pages/Settings/Product/Features/FeaturesIndex.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace GetCandy\Hub\Http\Livewire\Pages\Settings\Product\Features;
+
+use Livewire\Component;
+
+class FeaturesIndex extends Component
+{
+    /**
+     * Render the livewire component.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function render()
+    {
+        return view('adminhub::livewire.pages.settings.product.features.index')
+            ->layout('adminhub::layouts.settings', [
+                'menu' => 'settings',
+            ]);
+    }
+}

--- a/packages/admin/src/Menu/MenuRegistry.php
+++ b/packages/admin/src/Menu/MenuRegistry.php
@@ -2,6 +2,7 @@
 
 namespace GetCandy\Hub\Menu;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 
 class MenuRegistry
@@ -11,7 +12,7 @@ class MenuRegistry
      *
      * @var \Illuminate\Support\Collection
      */
-    protected $slots;
+    protected Collection $slots;
 
     /**
      * Initialise the class.
@@ -34,7 +35,7 @@ class MenuRegistry
     {
         $handle = Str::slug($handle);
 
-        $slot = $this->slots->first(function ($slot) use ($handle) {
+        $slot = $this->slots->first(function (MenuSlot $slot) use ($handle) {
             return $slot->getHandle() == $handle;
         });
 

--- a/packages/admin/src/Menu/SettingsMenu.php
+++ b/packages/admin/src/Menu/SettingsMenu.php
@@ -6,12 +6,14 @@ use GetCandy\Hub\Facades\Menu;
 
 class SettingsMenu
 {
+    protected MenuSlot $slot;
+
     /**
      * Make our menu.
      *
      * @return void
      */
-    public static function make()
+    public static function make(): void
     {
         (new static())
             ->makeTopLevel();
@@ -22,82 +24,132 @@ class SettingsMenu
      *
      * @return static
      */
-    protected function makeTopLevel()
+    protected function makeTopLevel(): static
     {
-        $slot = Menu::slot('settings');
+        $this->slot = Menu::slot('settings');
 
-        $storeSection = $slot->section('store')->name(
-            'Store'
-        );
-
-        $adminSection = $slot->section('admin')->name(
-            'Admin'
-        );
-
-        $storeSection->addItem(function ($item) {
-            $item->name('Attributes')
-                ->handle('hub.attributes')
-                ->route('hub.attributes.index')
-                ->gate('settings:manage-attributes')
-                ->icon('beaker');
-        });
-
-        $storeSection->addItem(function ($item) {
-            $item->name('Channels')
-                ->handle('hub.channels')
-                ->route('hub.channels.index')
-                ->gate('settings:core')
-                ->icon('server');
-        });
-
-        $storeSection->addItem(function ($item) {
-            $item->name('Currencies')
-                ->handle('hub.currencies')
-                ->route('hub.currencies.index')
-                ->gate('settings:core')
-                ->icon('currency-pound');
-        });
-
-        $storeSection->addItem(function ($item) {
-            $item->name('Languages')
-                ->handle('hub.languages')
-                ->route('hub.languages.index')
-                ->gate('settings:core')
-                ->icon('translate');
-        });
-
-        $storeSection->addItem(function ($item) {
-            $item->name('Tags')
-                ->handle('hub.tags')
-                ->route('hub.tags.index')
-                ->gate('settings:core')
-                ->icon('tag');
-        });
-
-        $adminSection->addItem(function ($item) {
-            $item->name('Activity Log')
-                ->handle('hub.activity-log')
-                ->route('hub.activity-log.index')
-                ->gate('settings')
-                ->icon('clipboard-list');
-        });
-
-        $adminSection->addItem(function ($item) {
-            $item->name('Addons')
-                ->handle('hub.addons')
-                ->route('hub.addons.index')
-                ->gate('settings:core')
-                ->icon('puzzle');
-        });
-
-        $adminSection->addItem(function ($item) {
-            $item->name('Staff')
-                ->handle('hub.staff')
-                ->route('hub.staff.index')
-                ->gate('settings:manage-staff')
-                ->icon('identification');
-        });
+        $this->makeStoreSection();
+        $this->makeProductSection();
+        $this->makeAdminSection();
 
         return $this;
+    }
+
+    /**
+     * Create the store sections.
+     *
+     * @return void
+     */
+    protected function makeStoreSection(): void
+    {
+        $storeSection = $this->slot->section('store')->name('Store');
+
+        $storeSection->addItem(function (MenuLink $item) {
+            $item->name('Attributes')
+                 ->handle('hub.attributes')
+                 ->route('hub.attributes.index')
+                 ->gate('settings:manage-attributes')
+                 ->icon('beaker');
+        });
+
+        $storeSection->addItem(function (MenuLink $item) {
+            $item->name('Channels')
+                 ->handle('hub.channels')
+                 ->route('hub.channels.index')
+                 ->gate('settings:core')
+                 ->icon('server');
+        });
+
+        $storeSection->addItem(function (MenuLink $item) {
+            $item->name('Currencies')
+                 ->handle('hub.currencies')
+                 ->route('hub.currencies.index')
+                 ->gate('settings:core')
+                 ->icon('currency-pound');
+        });
+
+        $storeSection->addItem(function (MenuLink $item) {
+            $item->name('Languages')
+                 ->handle('hub.languages')
+                 ->route('hub.languages.index')
+                 ->gate('settings:core')
+                 ->icon('translate');
+        });
+
+        $storeSection->addItem(function (MenuLink $item) {
+            $item->name('Tags')
+                 ->handle('hub.tags')
+                 ->route('hub.tags.index')
+                 ->gate('settings:core')
+                 ->icon('tag');
+        });
+    }
+
+    /**
+     * Create the product sections.
+     *
+     * @return void
+     */
+    protected function makeProductSection(): void
+    {
+        $productSection = $this->slot->section('product')->name('Product');
+
+        $productSection->addItem(function (MenuLink $item) {
+            $item->name('Features')
+                 ->handle('hub.product.features')
+                 ->route('hub.product.features.index')
+                 ->gate('settings:core')
+                 ->icon('clipboard-list');
+        });
+
+        // $productSection->addItem(function (MenuLink $item) {
+        //     $item->name('Options')
+        //          ->handle('hub.product.options')
+        //          ->route('hub.product.options.index')
+        //          ->gate('settings:core')
+        //          ->icon('clipboard-list');
+        // });
+        //
+        // $productSection->addItem(function (MenuLink $item) {
+        //     $item->name('Types')
+        //          ->handle('hub.product.types')
+        //          ->route('hub.product.types.index')
+        //          ->gate('settings:core')
+        //          ->icon('pencil');
+        // });
+    }
+
+    /**
+     * Create the admin sections.
+     *
+     * @return void
+     */
+    protected function makeAdminSection(): void
+    {
+        $adminSection = $this->slot->section('admin')->name('Admin');
+
+        $adminSection->addItem(function (MenuLink $item) {
+            $item->name('Activity Log')
+                 ->handle('hub.activity-log')
+                 ->route('hub.activity-log.index')
+                 ->gate('settings')
+                 ->icon('clipboard-list');
+        });
+
+        $adminSection->addItem(function (MenuLink $item) {
+            $item->name('Addons')
+                 ->handle('hub.addons')
+                 ->route('hub.addons.index')
+                 ->gate('settings:core')
+                 ->icon('puzzle');
+        });
+
+        $adminSection->addItem(function (MenuLink $item) {
+            $item->name('Staff')
+                 ->handle('hub.staff')
+                 ->route('hub.staff.index')
+                 ->gate('settings:manage-staff')
+                 ->icon('identification');
+        });
     }
 }

--- a/packages/admin/tests/Feature/Http/Livewire/Pages/Settings/Product/ProductFeaturesTest.php
+++ b/packages/admin/tests/Feature/Http/Livewire/Pages/Settings/Product/ProductFeaturesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace GetCandy\Hub\Tests\Feature\Http\Livewire\Pages\Settings\Product;
+
+use GetCandy\Hub\Models\Staff;
+use GetCandy\Hub\Tests\TestCase;
+use GetCandy\Models\Language;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group hub.activity-log
+ */
+class ProductFeaturesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        // Resolves the issue with tests failing where livewire components have translations
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+    }
+
+    /** @test */
+    public function cant_view_page_as_guest()
+    {
+        $this->get('/hub/settings/product/features')
+            ->assertRedirect(
+                route('hub.login')
+            );
+    }
+
+    /** @test */
+    public function can_view_page_when_authenticated()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $this->actingAs($staff, 'staff');
+
+        $this->get('/hub/settings/product/features')
+            ->assertSeeLivewire('hub.components.settings.product.features.index');
+    }
+}

--- a/packages/core/database/factories/ProductFeatureFactory.php
+++ b/packages/core/database/factories/ProductFeatureFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GetCandy\Database\Factories;
+
+use GetCandy\Models\ProductFeature;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductFeatureFactory extends Factory
+{
+    protected $model = ProductFeature::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => [
+                'en' => $this->faker->name,
+            ],
+        ];
+    }
+}

--- a/packages/core/database/factories/ProductFeatureFactory.php
+++ b/packages/core/database/factories/ProductFeatureFactory.php
@@ -4,17 +4,23 @@ namespace GetCandy\Database\Factories;
 
 use GetCandy\Models\ProductFeature;
 use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
 
 class ProductFeatureFactory extends Factory
 {
+    private static $position = 1;
+
     protected $model = ProductFeature::class;
 
     public function definition(): array
     {
+        $name = $this->faker->name;
         return [
+            'handle' => Str::slug($name),
             'name' => [
-                'en' => $this->faker->name,
+                'en' => $name,
             ],
+            'position' => self::$position++,
         ];
     }
 }

--- a/packages/core/database/factories/ProductFeatureValueFactory.php
+++ b/packages/core/database/factories/ProductFeatureValueFactory.php
@@ -2,12 +2,14 @@
 
 namespace GetCandy\Database\Factories;
 
-use GetCandy\Models\ProductOptionValue;
+use GetCandy\Models\ProductFeatureValue;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 class ProductFeatureValueFactory extends Factory
 {
-    protected $model = ProductOptionValue::class;
+    private static $position = 1;
+
+    protected $model = ProductFeatureValue::class;
 
     public function definition(): array
     {
@@ -15,6 +17,7 @@ class ProductFeatureValueFactory extends Factory
             'name' => [
                 'en' => $this->faker->name,
             ],
+            'position' => self::$position++,
         ];
     }
 }

--- a/packages/core/database/factories/ProductFeatureValueFactory.php
+++ b/packages/core/database/factories/ProductFeatureValueFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace GetCandy\Database\Factories;
+
+use GetCandy\Models\ProductOptionValue;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ProductFeatureValueFactory extends Factory
+{
+    protected $model = ProductOptionValue::class;
+
+    public function definition(): array
+    {
+        return [
+            'name' => [
+                'en' => $this->faker->name,
+            ],
+        ];
+    }
+}

--- a/packages/core/database/migrations/2022_07_14_111312_create_product_features_table.php
+++ b/packages/core/database/migrations/2022_07_14_111312_create_product_features_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use GetCandy\Base\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductFeaturesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->prefix.'product_features', function (Blueprint $table) {
+            $table->id();
+            $table->json('name');
+            $table->string('handle')->unique();
+            $table->integer('position')->default(0)->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix.'product_features');
+    }
+};

--- a/packages/core/database/migrations/2022_07_14_111313_create_product_feature_values_table.php
+++ b/packages/core/database/migrations/2022_07_14_111313_create_product_feature_values_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use GetCandy\Base\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateProductFeatureValuesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create($this->prefix.'product_feature_values', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('product_feature_id')->constrained($this->prefix.'product_features');
+            $table->integer('position')->default(0)->index();
+            $table->json('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists($this->prefix.'product_feature_values');
+    }
+};

--- a/packages/core/src/Models/ProductFeature.php
+++ b/packages/core/src/Models/ProductFeature.php
@@ -24,7 +24,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class ProductFeature extends BaseModel
 {
     use HasFactory;
-    use HasMedia;
     use HasTranslations;
     use Searchable;
     use HasMacros;

--- a/packages/core/src/Models/ProductFeature.php
+++ b/packages/core/src/Models/ProductFeature.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace GetCandy\Models;
+
+use GetCandy\Base\BaseModel;
+use GetCandy\Base\Traits\HasMacros;
+use GetCandy\Base\Traits\HasMedia;
+use GetCandy\Base\Traits\HasTranslations;
+use GetCandy\Base\Traits\Searchable;
+use GetCandy\Database\Factories\ProductFeatureFactory;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Class ProductFeature
+ * @package GetCandy\Models
+ *
+ * @property string $name
+ * @property string $handle
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
+class ProductFeature extends BaseModel
+{
+    use HasFactory;
+    use HasMedia;
+    use HasTranslations;
+    use Searchable;
+    use HasMacros;
+
+    /**
+     * Define our base filterable attributes.
+     *
+     * @var array
+     */
+    protected $filterable = [];
+
+    /**
+     * Define our base sortable attributes.
+     *
+     * @var array
+     */
+    protected $sortable = [
+        'name',
+    ];
+
+    /**
+     * Define which attributes should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'name' => AsCollection::class,
+    ];
+
+    /**
+     * Get the name of the index associated with the model.
+     *
+     * @return string
+     */
+    public function searchableAs()
+    {
+        return config('scout.prefix').'product_features';
+    }
+
+    /**
+     * Return a new factory instance for the model.
+     *
+     * @return \GetCandy\Database\Factories\ProductFeatureFactory
+     */
+    protected static function newFactory(): ProductFeatureFactory
+    {
+        return ProductFeatureFactory::new();
+    }
+
+    public function getNameAttribute($value)
+    {
+        return json_decode($value);
+    }
+
+    protected function setNameAttribute($value)
+    {
+        $this->attributes['name'] = json_encode($value);
+    }
+
+    /**
+     * Define which attributes should be
+     * protected from mass assignment.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    /**
+     * Get the product features values.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\HasMany
+     */
+    public function values(): HasMany
+    {
+        return $this->hasMany(ProductFeatureValue::class)->orderBy('position');
+    }
+}

--- a/packages/core/src/Models/ProductFeatureValue.php
+++ b/packages/core/src/Models/ProductFeatureValue.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace GetCandy\Models;
+
+use GetCandy\Base\BaseModel;
+use GetCandy\Base\Traits\HasMacros;
+use GetCandy\Base\Traits\HasMedia;
+use GetCandy\Base\Traits\HasTranslations;
+use GetCandy\Database\Factories\ProductFeatureValueFactory;
+use Illuminate\Database\Eloquent\Casts\AsCollection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ProductFeatureValue extends BaseModel
+{
+    use HasFactory;
+    use HasTranslations;
+    use HasMacros;
+
+    /**
+     * Define which attributes should be cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'name' => AsCollection::class,
+    ];
+
+    /**
+     * Return a new factory instance for the model.
+     *
+     * @return \GetCandy\Database\Factories\ProductFeatureValueFactory
+     */
+    protected static function newFactory(): ProductFeatureValueFactory
+    {
+        return ProductFeatureValueFactory::new();
+    }
+
+    /**
+     * Define which attributes should be
+     * protected from mass assignment.
+     *
+     * @var array
+     */
+    protected $guarded = [];
+
+    protected function setNameAttribute($value)
+    {
+        $this->attributes['name'] = json_encode($value);
+    }
+
+    public function getNameAttribute($value)
+    {
+        return json_decode($value);
+    }
+
+    /**
+     * Get the product feature this value belongs to.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function feature(): BelongsTo
+    {
+        return $this->belongsTo(ProductFeature::class, 'product_feature_id');
+    }
+}

--- a/packages/core/src/Models/ProductFeatureValue.php
+++ b/packages/core/src/Models/ProductFeatureValue.php
@@ -11,6 +11,15 @@ use Illuminate\Database\Eloquent\Casts\AsCollection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
+/**
+ * Class ProductFeatureValue
+ * @package GetCandy\Models
+ *
+ * @property string $name
+ * @property int $position
+ *
+ * @mixin \Illuminate\Database\Eloquent\Builder
+ */
 class ProductFeatureValue extends BaseModel
 {
     use HasFactory;
@@ -59,7 +68,7 @@ class ProductFeatureValue extends BaseModel
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function feature(): BelongsTo
+    public function productFeature(): BelongsTo
     {
         return $this->belongsTo(ProductFeature::class, 'product_feature_id');
     }

--- a/packages/core/tests/Unit/Jobs/Collections/UpdateProductPositionsTest.php
+++ b/packages/core/tests/Unit/Jobs/Collections/UpdateProductPositionsTest.php
@@ -14,7 +14,7 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 /**
  * @group getcandy.jobs
  */
-class NumberTest extends TestCase
+class UpdateProductPositionsTest extends TestCase
 {
     use RefreshDatabase;
 

--- a/packages/core/tests/Unit/Models/ProductFeatureTest.php
+++ b/packages/core/tests/Unit/Models/ProductFeatureTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Models;
+
+use GetCandy\Models\ProductFeature;
+use GetCandy\Models\ProductFeatureValue;
+use GetCandy\Tests\TestCase;
+use Illuminate\Database\QueryException;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+use Illuminate\Support\Str;
+
+class ProductFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_make_a_product_feature_with_translations()
+    {
+        $productFeature = ProductFeature::factory()->create();
+
+        $this->assertDatabaseHas((new ProductFeature)->getTable(), [
+            'id' => $productFeature->id,
+            'name' => json_encode($productFeature->name),
+            'handle' => $productFeature->handle,
+            'position' => $productFeature->position,
+        ]);
+
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 1);
+    }
+
+    /** @test */
+    public function handle_matches_name_default_locale()
+    {
+        /** @var ProductFeature $productFeature */
+        $productFeature = ProductFeature::factory()->create();
+
+        $this->assertEquals($productFeature->handle, Str::slug($productFeature->translate('name')));
+    }
+
+    /** @test */
+    public function handle_if_not_unique_throw_exception()
+    {
+        $productFeature = ProductFeature::factory()->create();
+
+        $this->expectException(QueryException::class);
+        $this->expectWarningMessage('UNIQUE constraint failed');
+        ProductFeature::factory()->create([
+            'handle' => $productFeature->handle,
+        ]);
+
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 1);
+
+        ProductFeature::factory()->create([
+            'handle' => $productFeature->handle.'-unique',
+        ]);
+
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 2);
+    }
+
+    /** @test */
+    public function can_update_all_product_feature_positions()
+    {
+        $productFeatures = ProductFeature::factory(10)->create()->each(function ($productFeature) {
+            $productFeature->update([
+                'position' => $productFeature->id,
+            ]);
+        });
+
+        $this->assertEquals(range(1,10), $productFeatures->pluck('position')->toArray());
+
+        $position = 10;
+        foreach ($productFeatures as $productFeature) {
+            $productFeature->position = $position;
+            $productFeature->save();
+            $position--;
+        }
+
+        $this->assertEquals(array_reverse(range(1,10)), $productFeatures->pluck('position')->toArray());
+    }
+
+    /** @test */
+    public function can_delete_product_feature()
+    {
+        $productFeature = ProductFeature::factory()->create();
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 1);
+
+        $productFeature->delete();
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 0);
+    }
+
+    /** @test */
+    public function can_delete_product_feature_by_handle()
+    {
+        $productFeature = ProductFeature::factory()->create();
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 1);
+
+        ProductFeature::where('handle', $productFeature->handle)->delete();
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 0);
+    }
+
+    /** @test */
+    public function can_create_feature_value()
+    {
+        $productFeature = ProductFeature::factory()->create();
+        $this->assertDatabaseCount((new ProductFeature)->getTable(), 1);
+
+        $productFeature->values()->create([
+            'name' => collect([
+                'en' => 'Feature Value 1 (EN)',
+                'fr' => 'Feature Value 1 (FR)',
+            ]),
+        ]);
+
+        $this->assertDatabaseCount((new ProductFeatureValue)->getTable(), 1);
+        $this->assertCount(1, ProductFeatureValue::whereRelation(
+            'feature',
+            'product_feature_id',
+            $productFeature->id)->get(),
+        );
+    }
+}

--- a/packages/core/tests/Unit/Models/ProductFeatureTest.php
+++ b/packages/core/tests/Unit/Models/ProductFeatureTest.php
@@ -114,7 +114,7 @@ class ProductFeatureTest extends TestCase
 
         $this->assertDatabaseCount((new ProductFeatureValue)->getTable(), 1);
         $this->assertCount(1, ProductFeatureValue::whereRelation(
-            'feature',
+            'productFeature',
             'product_feature_id',
             $productFeature->id)->get(),
         );

--- a/packages/core/tests/Unit/Models/ProductFeatureValueTest.php
+++ b/packages/core/tests/Unit/Models/ProductFeatureValueTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace GetCandy\Tests\Unit\Models;
+
+use GetCandy\Models\ProductFeature;
+use GetCandy\Models\ProductFeatureValue;
+use GetCandy\Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ProductFeatureValueTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test */
+    public function can_make_a_product_feature_value_with_translations()
+    {
+        $featureValue = ProductFeatureValue
+            ::factory()
+            ->for(ProductFeature::factory(), 'productFeature')
+            ->create();
+
+        $this->assertDatabaseHas((new ProductFeatureValue)->getTable(), [
+            'id' => $featureValue->id,
+            'product_feature_id' => $featureValue->productFeature->id,
+            'name' => json_encode($featureValue->name),
+        ]);
+
+        $this->assertDatabaseCount((new ProductFeatureValue)->getTable(), 1);
+    }
+
+    /** @test */
+    public function can_edit_translated_product_feature_value()
+    {
+        /** @var ProductFeatureValue $featureValue */
+        $featureValue = ProductFeatureValue
+            ::factory()
+            ->for(ProductFeature::factory(), 'productFeature')
+            ->create();
+
+        $featureValue->update(['name' => $updatedName = collect([
+            'en' => $featureValue->translate('name'). '-edited',
+        ])]);
+
+        $this->assertDatabaseHas((new ProductFeatureValue)->getTable(), [
+            'id' => $featureValue->id,
+            'product_feature_id' => $featureValue->productFeature->id,
+            'name' => $updatedName->toJson(),
+        ]);
+    }
+
+    /** @test */
+    public function can_delete_product_feature_value()
+    {
+        /** @var ProductFeatureValue $featureValue */
+        $featureValue = ProductFeatureValue
+            ::factory()
+            ->for(ProductFeature::factory(), 'productFeature')
+            ->create();
+
+        $featureValue->delete();
+
+        $this->assertDatabaseMissing((new ProductFeatureValue)->getTable(), [
+            'id' => $featureValue->id,
+        ]);
+    }
+
+    /** @test */
+    public function can_update_all_product_feature_value_positions()
+    {
+        $productFeatureValues = ProductFeatureValue
+            ::factory(10)
+            ->for(ProductFeature::factory(), 'productFeature')
+            ->create()
+            ->each(function ($featureValue) {
+                $featureValue->update([
+                    'position' => $featureValue->id,
+                ]);
+            });
+
+        $this->assertDatabaseCount((new ProductFeatureValue)->getTable(), 10);
+        $this->assertEquals(range(1,10), $productFeatureValues->pluck('position')->toArray());
+    }
+}


### PR DESCRIPTION
Here is my 1st PR extending settings which includes (small refactor of SettingsMenu) 

Requested by our client, previously using Prestashop they could manage a global list of attributes and features.
I have created a new menu group under settings called "Product" This new addition in this 1st PR called "Features"

Currently this is only for features. I would like to extend on this to add another new menu item for attributes which will be called "Options" to again handle the global list and be able to define each product option (group) field type for example colour picker.  This way our client can manage a global list of translatable features and values.

Additionally and will be created next week in another PR.
I plan to extend the ProductType Attributes field currently you have List type.
This is where user enters their values, which is great for some custom information on their site.

I will propose a new Dynamic List field type where you can choose a model.
For example if the model selected is ProductFeature then the user will be able to select a feature which will automatically populate the list with the feature values which can then be sorted within the ProductType page and the possibility to override via the product page.

I have created a basic set of tests for this PR.
Please let me know if any further tests are required.

Also I can put another PR together for the demo site to include seeders for this new feature if required.