### PR TITLE
Dynamic attribute group models

### DIFF
--- a/packages/admin/resources/lang/en/components.php
+++ b/packages/admin/resources/lang/en/components.php
@@ -42,7 +42,7 @@ return [
     'attribute-group-edit.name.placeholder'     => 'e.g. Additional Details',
     'attribute-group-edit.create_btn'           => 'Create attribute group',
     'attribute-group-edit.update_btn'           => 'Update attribute group',
-    'attribute-group-edit.non_unique_handle'    => 'This name has been already been taken',
+    'attribute-group-edit.non_unique_handle'    => 'This name has already been taken',
     /**
      * Attribute show.
      */

--- a/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
@@ -50,8 +50,8 @@
     :error="$errors->first('attributeGroup.type')"
   >
     <x-hub::input.select wire:model="attributeGroup.source">
-      @foreach($this->collectionTypes as $collectionType)
-        <option value="{{ \GetCandy\Models\Collection::class.'::'.$collectionType }}">{{ $collectionType }}</option>
+      @foreach($this->collectionGroups as $collectionGroup)
+        <option value="{{ \GetCandy\Models\Collection::class.'::'.$collectionGroup }}">{{ $collectionGroup }}</option>
       @endforeach
     </x-hub::input.select>
   </x-hub::input.group>

--- a/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
@@ -32,12 +32,26 @@
   @if($attributeGroup->type === 'model')
     <x-hub::input.group
     for="type"
-    :label="__('Select Model')"
+    :label="__('Model')"
     :error="$errors->first('attributeGroup.type')"
   >
     <x-hub::input.select wire:model="attributeGroup.source">
       @foreach($this->modelsCollection as $model)
         <option value="{{ $model }}">{{ $model }}</option>
+      @endforeach
+    </x-hub::input.select>
+  </x-hub::input.group>
+  @endif
+
+  @if($attributeGroup->type === 'model' && $attributeGroup->source === \GetCandy\Models\Collection::class)
+    <x-hub::input.group
+    for="type"
+    :label="__('Select Collection')"
+    :error="$errors->first('attributeGroup.type')"
+  >
+    <x-hub::input.select wire:model="attributeGroup.source">
+      @foreach($this->collectionTypes as $collectionType)
+        <option value="{{ \GetCandy\Models\Collection::class.'::'.$collectionType }}">{{ $collectionType }}</option>
       @endforeach
     </x-hub::input.select>
   </x-hub::input.group>

--- a/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/attributes/attribute-group-edit.blade.php
@@ -1,4 +1,4 @@
-<form wire:submit.prevent="create">
+<form wire:submit.prevent="create" class="space-y-2">
   <x-hub::input.group :label="__('adminhub::inputs.name')" for="name" :error="$errors->first('attributeGroup.name.' . $this->defaultLanguage->code)">
     <x-hub::translatable>
       <x-hub::input.text
@@ -16,6 +16,32 @@
       @endforeach
     </x-hub::translatable>
   </x-hub::input.group>
+
+  <x-hub::input.group
+    for="type"
+    :label="__('adminhub::inputs.type.label')"
+    :error="$errors->first('attributeGroup.type')"
+  >
+    <x-hub::input.select wire:model="attributeGroup.type">
+      @foreach($this->groupTypes as $groupType => $groupTypeName)
+        <option value="{{ $groupType }}">{{ $groupTypeName }}</option>
+      @endforeach
+    </x-hub::input.select>
+  </x-hub::input.group>
+
+  @if($attributeGroup->type === 'model')
+    <x-hub::input.group
+    for="type"
+    :label="__('Select Model')"
+    :error="$errors->first('attributeGroup.type')"
+  >
+    <x-hub::input.select wire:model="attributeGroup.source">
+      @foreach($this->modelsCollection as $model)
+        <option value="{{ $model }}">{{ $model }}</option>
+      @endforeach
+    </x-hub::input.select>
+  </x-hub::input.group>
+  @endif
 
   @if($errors->has('attributeGroup.handle'))
     <div class="mt-4">

--- a/packages/admin/resources/views/livewire/components/settings/attributes/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/attributes/show.blade.php
@@ -81,8 +81,10 @@
                 <div class="py-4 pl-2 pr-4 mt-2 space-y-2 bg-black border-l rounded bg-opacity-5 ml-7"
                      @if ($group->attributes->count()) x-show="expanded" @endif>
                     <div class="space-y-2"
+                         @if($group->type == 'default')
                          wire:sort
                          sort.options='{group: "attributes", method: "sortAttributes", owner: {{ $group->id }}}'
+                         @endif
                          x-show="expanded">
                         @foreach ($group->attributes as $attribute)
                             <div class="flex items-center justify-between w-full p-3 text-sm bg-white border border-transparent rounded shadow-sm sort-item-element hover:border-gray-300"
@@ -90,38 +92,42 @@
                                  sort.item="attributes"
                                  sort.parent="{{ $group->id }}"
                                  sort.id="{{ $attribute->id }}">
-                                <div sort.handle
-                                     class="cursor-grab">
-                                    <x-hub::icon ref="selector"
-                                                 style="solid"
-                                                 class="mr-2 text-gray-400 hover:text-gray-700" />
-                                </div>
-                                <span class="truncate grow">{{ $attribute->translate('name') }}</span>
-                                <div class="mr-4 text-xs text-gray-500">
-                                    {{ class_basename($attribute->type) }}
-                                </div>
-                                <div>
-                                    <x-hub::dropdown minimal>
-                                        <x-slot name="options">
-                                            <x-hub::dropdown.button type="button"
-                                                                    wire:click="$set('editAttributeId', {{ $attribute->id }})"
-                                                                    class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50">
-                                                {{ __('adminhub::components.attributes.show.edit_attribute_btn') }}
-                                                <x-hub::icon ref="pencil"
-                                                             style="solid"
-                                                             class="w-4" />
-                                            </x-hub::dropdown.button>
-
-                                            @if (!$attribute->system)
-                                                <x-hub::dropdown.button wire:click="$set('deleteAttributeId', {{ $attribute->id }})"
-                                                                        class="flex items-center justify-between px-4 py-2 text-sm border-b hover:bg-gray-50">
-                                                    <span
-                                                          class="text-red-500">{{ __('adminhub::components.attributes.show.delete_attribute_btn') }}</span>
+                                @if($group->type == 'default')
+                                    <div sort.handle
+                                         class="cursor-grab">
+                                        <x-hub::icon ref="selector"
+                                                     style="solid"
+                                                     class="mr-2 text-gray-400 hover:text-gray-700" />
+                                    </div>
+                                    <span class="truncate grow">{{ $attribute->translate('name') }}</span>
+                                    <div class="mr-4 text-xs text-gray-500">
+                                        {{ class_basename($attribute->type) }}
+                                    </div>
+                                    <div>
+                                        <x-hub::dropdown minimal>
+                                            <x-slot name="options">
+                                                <x-hub::dropdown.button type="button"
+                                                                        wire:click="$set('editAttributeId', {{ $attribute->id }})"
+                                                                        class="flex items-center justify-between px-4 py-2 text-sm text-gray-700 border-b hover:bg-gray-50">
+                                                    {{ __('adminhub::components.attributes.show.edit_attribute_btn') }}
+                                                    <x-hub::icon ref="pencil"
+                                                                 style="solid"
+                                                                 class="w-4" />
                                                 </x-hub::dropdown.button>
-                                            @endif
-                                        </x-slot>
-                                    </x-hub::dropdown>
-                                </div>
+
+                                                @if (!$attribute->system)
+                                                    <x-hub::dropdown.button wire:click="$set('deleteAttributeId', {{ $attribute->id }})"
+                                                                            class="flex items-center justify-between px-4 py-2 text-sm border-b hover:bg-gray-50">
+                                                        <span
+                                                              class="text-red-500">{{ __('adminhub::components.attributes.show.delete_attribute_btn') }}</span>
+                                                    </x-hub::dropdown.button>
+                                                @endif
+                                            </x-slot>
+                                        </x-hub::dropdown>
+                                    </div>
+                                @else
+                                    <span class="truncate grow">{{ $attribute->translate('name') }}</span>
+                                @endif
                             </div>
                         @endforeach
                     </div>

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -2,7 +2,6 @@
 
 namespace GetCandy\Hub\Http\Livewire\Components\Settings\Attributes;
 
-use GetCandy\Facades\FieldTypeManifest;
 use GetCandy\Hub\Http\Livewire\Traits\Notifies;
 use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
 use GetCandy\Models\AttributeGroup;
@@ -45,8 +44,8 @@ class AttributeGroupEdit extends Component
     public function rules()
     {
         return [
-            "attributeGroup.type" => "required",
-            "attributeGroup.source" => "required_if:attributeGroup.type,model",
+            'attributeGroup.type' => 'required',
+            'attributeGroup.source' => 'required_if:attributeGroup.type,model',
             "attributeGroup.name.{$this->defaultLanguage->code}" => [
                 'required',
                 'string',
@@ -79,19 +78,20 @@ class AttributeGroupEdit extends Component
 
     /**
      * Return the models collection.
+     *
      * @todo Activate features once merged and any other model you would like to use
      *
      * @return \Illuminate\Support\Collection
      */
-public function getModelsCollectionProperty(): Collection
-{
-    return collect([
-        '--' => 'Select a model',
-        'collection' => CollectionModel::class,
-        //'features' => ProductFeature::class,
-        'options' => ProductOption::class,
-    ]);
-}
+    public function getModelsCollectionProperty(): Collection
+    {
+        return collect([
+            '--' => 'Select a model',
+            'collection' => CollectionModel::class,
+            //'features' => ProductFeature::class,
+            'options' => ProductOption::class,
+        ]);
+    }
 
     /**
      * Return all collection groups.

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -8,7 +8,6 @@ use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
 use GetCandy\Models\AttributeGroup;
 use GetCandy\Models\Collection as CollectionModel;
 use GetCandy\Models\CollectionGroup;
-use GetCandy\Models\ProductFeature;
 use GetCandy\Models\ProductOption;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -46,7 +46,7 @@ class AttributeGroupEdit extends Component
     {
         return [
             "attributeGroup.type" => "required",
-            "attributeGroup.source" => "sometimes|required",
+            //"attributeGroup.source" => "required_if:attributeGroup.type,model",
             "attributeGroup.name.{$this->defaultLanguage->code}" => [
                 'required',
                 'string',
@@ -86,7 +86,7 @@ class AttributeGroupEdit extends Component
     public function getModelsCollectionProperty(): Collection
     {
         return collect([
-            '' => 'Select a model',
+            '--' => 'Select a model',
             'collection' => CollectionModel::class,
             //'features' => ProductFeature::class,
             'options' => ProductOption::class,
@@ -106,16 +106,15 @@ class AttributeGroupEdit extends Component
         ]);
     }
 
+    /**
+     * @todo Rename to save then refactor to inject single action
+     */
     public function create()
     {
         $this->validate();
 
-        $handle = Str::handle("{$this->typeHandle}_{$this->attributeGroup->translate('name')}");
+        $handle = Str::handle($this->attributeGroup->translate('name'));
         $this->attributeGroup->handle = $handle;
-
-        $this->validate([
-            'attributeGroup.handle' => 'unique:'.get_class($this->attributeGroup).',handle',
-        ]);
 
         if ($this->attributeGroup->id) {
             $this->attributeGroup->save();
@@ -126,6 +125,10 @@ class AttributeGroupEdit extends Component
 
             return;
         }
+
+        $this->validate([
+            'attributeGroup.handle' => 'unique:'.get_class($this->attributeGroup).',handle',
+        ]);
 
         $this->attributeGroup->attributable_type = $this->attributableType;
         $this->attributeGroup->position = AttributeGroup::whereAttributableType(

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -2,9 +2,14 @@
 
 namespace GetCandy\Hub\Http\Livewire\Components\Settings\Attributes;
 
+use GetCandy\Facades\FieldTypeManifest;
 use GetCandy\Hub\Http\Livewire\Traits\Notifies;
 use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
 use GetCandy\Models\AttributeGroup;
+use GetCandy\Models\Collection as CollectionModel;
+use GetCandy\Models\ProductFeature;
+use GetCandy\Models\ProductOption;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Livewire\Component;
 
@@ -40,6 +45,8 @@ class AttributeGroupEdit extends Component
     public function rules()
     {
         return [
+            "attributeGroup.type" => "required",
+            "attributeGroup.source" => "sometimes|required",
             "attributeGroup.name.{$this->defaultLanguage->code}" => [
                 'required',
                 'string',
@@ -54,6 +61,34 @@ class AttributeGroupEdit extends Component
     public function mount()
     {
         $this->attributeGroup = $this->attributeGroup ?: new AttributeGroup();
+        $this->attributeGroup->type = $this->getGroupTypesProperty()->keys()->first();
+    }
+
+    /**
+     * Return the available group types.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getGroupTypesProperty(): Collection
+    {
+        return collect([
+            'default' => 'Default',
+            'model' => 'Model',
+        ]);
+    }
+
+    /**
+     * Return the models collection.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getModelsCollectionProperty(): Collection
+    {
+        return collect([
+            'brands' => CollectionModel::class,
+            'features' => ProductFeature::class,
+            'options' => ProductOption::class,
+        ]);
     }
 
     public function create()

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -46,7 +46,7 @@ class AttributeGroupEdit extends Component
     {
         return [
             "attributeGroup.type" => "required",
-            //"attributeGroup.source" => "required_if:attributeGroup.type,model",
+            "attributeGroup.source" => "required_if:attributeGroup.type,model",
             "attributeGroup.name.{$this->defaultLanguage->code}" => [
                 'required',
                 'string',

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -7,6 +7,7 @@ use GetCandy\Hub\Http\Livewire\Traits\Notifies;
 use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
 use GetCandy\Models\AttributeGroup;
 use GetCandy\Models\Collection as CollectionModel;
+use GetCandy\Models\CollectionGroup;
 use GetCandy\Models\ProductFeature;
 use GetCandy\Models\ProductOption;
 use Illuminate\Support\Collection;
@@ -83,27 +84,24 @@ class AttributeGroupEdit extends Component
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getModelsCollectionProperty(): Collection
-    {
-        return collect([
-            '--' => 'Select a model',
-            'collection' => CollectionModel::class,
-            //'features' => ProductFeature::class,
-            'options' => ProductOption::class,
-        ]);
-    }
+public function getModelsCollectionProperty(): Collection
+{
+    return collect([
+        '--' => 'Select a model',
+        'collection' => CollectionModel::class,
+        //'features' => ProductFeature::class,
+        'options' => ProductOption::class,
+    ]);
+}
 
     /**
-     * Return the collection types.
+     * Return all collection groups.
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getCollectionTypesProperty(): Collection
+    public function getCollectionGroupsProperty(): Collection
     {
-        return collect([
-            'categories' => 'Categories',
-            'brands' => 'Brands',
-        ]);
+        return CollectionGroup::pluck('name', 'handle');
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeGroupEdit.php
@@ -79,15 +79,30 @@ class AttributeGroupEdit extends Component
 
     /**
      * Return the models collection.
+     * @todo Activate features once merged and any other model you would like to use
      *
      * @return \Illuminate\Support\Collection
      */
     public function getModelsCollectionProperty(): Collection
     {
         return collect([
-            'brands' => CollectionModel::class,
-            'features' => ProductFeature::class,
+            '' => 'Select a model',
+            'collection' => CollectionModel::class,
+            //'features' => ProductFeature::class,
             'options' => ProductOption::class,
+        ]);
+    }
+
+    /**
+     * Return the collection types.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getCollectionTypesProperty(): Collection
+    {
+        return collect([
+            'categories' => 'Categories',
+            'brands' => 'Brands',
         ]);
     }
 

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -148,6 +148,7 @@ class AttributeShow extends AbstractAttribute
 
                 // Retrieve dynamic attributes again
                 $group->attributes = $attributes;
+
                 return $group;
             })->sortBy('position');
         });

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -139,9 +139,15 @@ class AttributeShow extends AbstractAttribute
                 $updatedOrder = collect($groups['items'])->first(function ($updated) use ($group) {
                     return $updated['id'] == $group->id;
                 });
-                $group->position = $updatedOrder['order'];
-                $group->save();
 
+                // Ignore dynamic attributes when updating
+                $attributes = $group->attributes;
+                unset($group->attributes);
+
+                $group->update(['position' => $updatedOrder['order']]);
+
+                // Retrieve dynamic attributes again
+                $group->attributes = $attributes;
                 return $group;
             })->sortBy('position');
         });
@@ -181,9 +187,7 @@ class AttributeShow extends AbstractAttribute
      */
     public function refreshGroups()
     {
-        $this->sortedAttributeGroups = AttributeGroup::whereAttributableType($this->typeClass)
-        ->orderBy('position')->get();
-
+        $this->sortedAttributeGroups = $this->attributeGroups;
         $this->showGroupCreate = false;
     }
 
@@ -313,6 +317,11 @@ class AttributeShow extends AbstractAttribute
 
         $this->deleteAttributeId = null;
         $this->refreshGroups();
+    }
+
+    public function updated(): void
+    {
+        $this->sortedAttributeGroups = $this->attributeGroups;
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -105,10 +105,20 @@ class AttributeShow extends AbstractAttribute
      *
      * @return \Illuminate\Support\Collection
      */
-    public function getAttributeGroupsProperty()
+    public function getAttributeGroupsProperty(): Collection
     {
         return AttributeGroup::whereAttributableType($this->typeClass)
-            ->orderBy('position')->get();
+            ->with('attributes')
+            ->orderBy('position')
+            ->get()
+            ->map(function ($group) {
+                if ($group->type === 'model' && $group->source) {
+                    /** @var \Illuminate\Database\Eloquent\Model $model */
+                    $model = app($group->source);
+                    $group->attributes = $model::all();
+                }
+                return $group;
+            });
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -2,6 +2,7 @@
 
 namespace GetCandy\Hub\Http\Livewire\Components\Settings\Attributes;
 
+use GetCandy\Base\Traits\WithModelAttributeGroup;
 use GetCandy\Facades\AttributeManifest;
 use GetCandy\Hub\Http\Livewire\Traits\Notifies;
 use GetCandy\Hub\Http\Livewire\Traits\WithLanguages;
@@ -14,6 +15,7 @@ class AttributeShow extends AbstractAttribute
 {
     use Notifies;
     use WithLanguages;
+    use WithModelAttributeGroup;
 
     /**
      * The type property.
@@ -111,18 +113,7 @@ class AttributeShow extends AbstractAttribute
             ->with('attributes')
             ->orderBy('position')
             ->get()
-            ->map(function ($group) {
-                if ($group->type === 'model' && $group->source) {
-                    try {
-                        /** @var \Illuminate\Database\Eloquent\Model $model */
-                        $model = app($group->source);
-                        $group->attributes = $model::all();
-                    } catch (\Exception $e) {
-                        //dd($e->getMessage());
-                    }
-                }
-                return $group;
-            });
+            ->map(fn ($group) => $this->getAttributeGroupFromModel($group));
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Settings/Attributes/AttributeShow.php
@@ -113,9 +113,13 @@ class AttributeShow extends AbstractAttribute
             ->get()
             ->map(function ($group) {
                 if ($group->type === 'model' && $group->source) {
-                    /** @var \Illuminate\Database\Eloquent\Model $model */
-                    $model = app($group->source);
-                    $group->attributes = $model::all();
+                    try {
+                        /** @var \Illuminate\Database\Eloquent\Model $model */
+                        $model = app($group->source);
+                        $group->attributes = $model::all();
+                    } catch (\Exception $e) {
+                        //dd($e->getMessage());
+                    }
                 }
                 return $group;
             });

--- a/packages/admin/tests/Feature/Http/Livewire/Pages/Settings/Attributes/AttributesShowTest.php
+++ b/packages/admin/tests/Feature/Http/Livewire/Pages/Settings/Attributes/AttributesShowTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace GetCandy\Hub\Tests\Feature\Http\Livewire\Pages\Settings\Attributes;
+
+use GetCandy\Hub\Models\Staff;
+use GetCandy\Hub\Tests\TestCase;
+use GetCandy\Models\Language;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+/**
+ * @group attributes
+ */
+class AttributesShowTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+    }
+
+    /** @test */
+    public function cant_view_page_as_guest()
+    {
+        $this->get('/hub/settings/attributes/*')
+            ->assertRedirect(
+                route('hub.login')
+            );
+    }
+
+    /** @test */
+    public function can_view_page_when_authenticated()
+    {
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+        $this->actingAs($staff, 'staff');
+
+        $this->get('/hub/settings/attributes/product')
+            ->assertSeeLivewire('hub.components.settings.attributes.show');
+    }
+}

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Attributes/AttributeGroupModelCreateTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Settings/Attributes/AttributeGroupModelCreateTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace GetCandy\Hub\Tests\Unit\Http\Livewire\Components\Settings\Attributes;
+
+use GetCandy\Hub\Http\Livewire\Components\Settings\Attributes\AttributeGroupEdit;
+use GetCandy\Hub\Http\Livewire\Components\Settings\Attributes\AttributeShow;
+use GetCandy\Hub\Tests\TestCase;
+use GetCandy\Models\AttributeGroup;
+use GetCandy\Models\Collection;
+use GetCandy\Models\CollectionGroup;
+use GetCandy\Models\Language;
+use GetCandy\Models\Product;
+use GetCandy\Models\ProductOption;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+
+class AttributeGroupModelCreateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+    }
+
+    /** @test */
+    public function can_create_product_options_group()
+    {
+        ProductOption::factory()->create(['name' => 'Sizes']);
+        ProductOption::factory()->create(['name' => 'Color']);
+
+        $data = [
+            'type'     => 'model',
+            'source'   => ProductOption::class,
+            'name'     => 'Product Options',
+            'handle'   => 'product_options',
+            'position' => 1,
+        ];
+
+        Livewire::test(AttributeGroupEdit::class, [
+            'typeHandle' => 'product',
+            'attributableType' => Product::class,
+        ])
+            ->set('attributeGroup.name.en', $data['name'])
+            ->set('attributeGroup.type', $data['type'])
+            ->set('attributeGroup.source', $data['source'])
+            ->call('create');
+
+        $data['name'] = collect(['en' => $data['name']])->toJson();
+        $this->assertDatabaseHas((new AttributeGroup)->getTable(), $data);
+    }
+
+    /** @test */
+    public function can_create_brands_collection_group()
+    {
+        CollectionGroup::factory()->create([
+            'name'   => 'Brands',
+            'handle' => 'brands',
+        ]);
+
+        $data = [
+            'type'     => 'model',
+            'source'   => Collection::class,
+            'name'     => 'Brands',
+            'handle'   => 'brands',
+            'position' => 1,
+        ];
+
+        Livewire::test(AttributeGroupEdit::class, [
+            'typeHandle' => 'product',
+            'attributableType' => Product::class,
+        ])
+            ->set('attributeGroup.name.en', $data['name'])
+            ->set('attributeGroup.type', $data['type'])
+            ->set('attributeGroup.source', $data['source'])
+            ->assertSee('Select Collection')
+            ->assertSee('Brands')
+            ->call('create');
+
+        $data['name'] = collect(['en' => $data['name']])->toJson();
+        $this->assertDatabaseHas((new AttributeGroup)->getTable(), $data);
+    }
+
+    /** @test */
+    public function can_see_product_options_on_mount()
+    {
+        // Run the previous test 1st to create the product options group
+        $this->can_create_product_options_group();
+
+        Livewire::test(AttributeShow::class, ['type' => 'product'])
+            ->assertSee('Product Options')
+            ->assertSeeTextInOrder(ProductOption::pluck('name')->toArray());
+    }
+
+    /** @test */
+    public function can_see_product_options_on_update()
+    {
+        // Run the previous test 1st to create the product options group
+        $this->can_create_product_options_group();
+
+        Livewire::test(AttributeShow::class, ['type' => 'product'])
+                ->call('refreshGroups')
+                ->assertSee('Product Options')
+                ->assertSeeTextInOrder(ProductOption::pluck('name')->toArray());
+    }
+}

--- a/packages/core/database/migrations/2022_07_17_215417_add_type_model_to_attribute_groups_table.php
+++ b/packages/core/database/migrations/2022_07_17_215417_add_type_model_to_attribute_groups_table.php
@@ -31,4 +31,4 @@ class AddTypeModelToAttributeGroupsTable extends Migration
             $table->dropColumn('source');
         });
     }
-};
+}

--- a/packages/core/database/migrations/2022_07_17_215417_add_type_model_to_attribute_groups_table.php
+++ b/packages/core/database/migrations/2022_07_17_215417_add_type_model_to_attribute_groups_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use GetCandy\Base\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddTypeModelToAttributeGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table($this->prefix.'attribute_groups', function (Blueprint $table) {
+            $table->string('type')->after('attributable_type')->default('default');
+            $table->string('source')->after('type')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table($this->prefix.'attribute_groups', function (Blueprint $table) {
+            $table->dropColumn('type');
+            $table->dropColumn('source');
+        });
+    }
+};

--- a/packages/core/src/Base/Traits/WithModelAttributeGroup.php
+++ b/packages/core/src/Base/Traits/WithModelAttributeGroup.php
@@ -7,14 +7,14 @@ use GetCandy\Models\AttributeGroup;
 trait WithModelAttributeGroup
 {
     /**
-     * Get attribute group from model and override attribures from source.
-     * @param  \GetCandy\Models\AttributeGroup  $group
+     * Get attribute group from model and override attributes from source.
      *
+     * @param  \GetCandy\Models\AttributeGroup  $group
      * @return \GetCandy\Models\AttributeGroup
      */
     protected function getAttributeGroupFromModel(AttributeGroup $group): AttributeGroup
     {
-        if (!$group->source) {
+        if (! $group->source) {
             return $group;
         }
 

--- a/packages/core/src/Base/Traits/WithModelAttributeGroup.php
+++ b/packages/core/src/Base/Traits/WithModelAttributeGroup.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace GetCandy\Base\Traits;
+
+use GetCandy\Models\AttributeGroup;
+
+trait WithModelAttributeGroup
+{
+    /**
+     * Get attribute group from model and override attribures from source.
+     * @param  \GetCandy\Models\AttributeGroup  $group
+     *
+     * @return \GetCandy\Models\AttributeGroup
+     */
+    protected function getAttributeGroupFromModel(AttributeGroup $group): AttributeGroup
+    {
+        if (!$group->source) {
+            return $group;
+        }
+
+        try {
+            /** @var \Illuminate\Database\Eloquent\Model $model */
+            $model = app($group->source);
+            $group->attributes = $model::all();
+        } catch (\Exception $e) {
+            //dd($e->getMessage());
+        }
+
+        return $group;
+    }
+}

--- a/packages/core/tests/Unit/Models/AttributeGroupTest.php
+++ b/packages/core/tests/Unit/Models/AttributeGroupTest.php
@@ -4,6 +4,8 @@ namespace GetCandy\Tests\Unit\Models;
 
 use GetCandy\Models\Attribute;
 use GetCandy\Models\AttributeGroup;
+use GetCandy\Models\Product;
+use GetCandy\Models\ProductOption;
 use GetCandy\Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -47,5 +49,23 @@ class AttributeGroupTest extends TestCase
         );
 
         $this->assertCount(1, $attributeGroup->refresh()->attributes);
+    }
+
+    /** @test */
+    public function can_make_dynamic_attribute_group_for_product_options()
+    {
+        $attributeGroup = AttributeGroup::factory()->create([
+            'type' => 'model',
+            'attributable_type' => Product::class,
+            'source' => ProductOption::class,
+            'name' => ['en' => 'Product Options'],
+            'handle' => 'product_options',
+            'position' => 2,
+        ]);
+
+        $this->assertEquals('Product Options', $attributeGroup->name->get('en'));
+        $this->assertEquals('product_options', $attributeGroup->handle);
+        $this->assertEquals(ProductOption::class, $attributeGroup->source);
+        $this->assertEquals(2, $attributeGroup->position);
     }
 }


### PR DESCRIPTION
Currently adding a custom attribute group via the settings for example `attributes/product` allows you to add a group and then manually set the values. This is a great and gives quite a lot of flexibility to add custom fields.

This small PR extends this feature to support dynamic groups.
In the example below I am using this for Product Options & Collections

The following models are supported (Note: ProductFeature currently not enabled until #405 has been approved)
```php
public function getModelsCollectionProperty(): Collection
{
    return collect([
        '--' => 'Select a model',
        'collection' => CollectionModel::class,
        //'features' => ProductFeature::class,
        'options' => ProductOption::class,
    ]);
}
```

Note: Selecting collections will automatically populate all your collection groups.
Another use case for example could be BlogPostModel which will allow you to display a post either across a product type or a post, the idea is you will be able to use any model currently manually defined in ModelsCollectionProperty.

The next PR shortly which will be linked below will enable you to use these new dynamic groups for ProductType.
This will include an example of managing both Product Options & Product Features where different configurations can be setup for each product type.

<img width="1589" alt="Screenshot 2022-07-22 at 11 52 23" src="https://user-images.githubusercontent.com/53559175/180432509-9f08c98a-12af-4cfe-9770-bcf404844e75.png">
<img width="1534" alt="Screenshot 2022-07-22 at 11 45 44" src="https://user-images.githubusercontent.com/53559175/180432515-8fd97a2d-5d9b-4746-aff2-fcafb8aad32c.png">