### PR TITLE
Feat - Move order reference generator to config

### DIFF
--- a/docs/src/getcandy/orders.md
+++ b/docs/src/getcandy/orders.md
@@ -97,6 +97,57 @@ $cart->getManager()->canCreateOrder();
 
 This essentially does the same as above, except we already catch the exceptions for you and just return false if any are caught.
 
+## Order Reference Generating
+
+By default GetCandy will generate a new order reference for you when you create an order from a cart. The format for this is:
+
+```
+{year}-{month}-{0..0}{orderId}
+```
+
+`{0..0}` indicates the order id will be padded with up to four `0`'s for example:
+
+```
+2022-01-0001
+2022-01-0011
+2022-01-0111
+2022-01-1111
+```
+
+### Custom Generators
+
+If your store has a specific requirement for how references are generated, you can easily swap out the GetCandy one for your own:
+
+`config/getcandy/orders.php`
+
+```php
+return [
+    'reference_generator' => App\Generators\MyCustomGenerator::class,
+];
+```
+
+Or, if you don't want references at all (not recommended) you can simply set it to `null`
+
+Here's the underlying class for the custom generator:
+
+```php
+namespace App\Generators;
+
+use GetCandy\Models\Order;
+
+class MyCustomGenerator implements OrderReferenceGeneratorInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function generate(Order $order): string
+    {
+        // ...
+        return 'my-custom-reference';
+    }
+}
+```
+
 ## Modifying Orders
 
 If you need to programmatically change the Order values or add in new behaviour, you will want to extend the Order system.

--- a/docs/src/upgrading.md
+++ b/docs/src/upgrading.md
@@ -128,6 +128,11 @@ Finally, you will need to define a dynamic relationship if your service provider
 });
 ```
 
+### Removal of `override` method for OrderReferenceGenerator - Medium Impact
+
+If you're using the `override` method to generator your own order references, this has been removed in favour of a config based approach. 
+You should update your code to reflect this, see [Orders](/getcandy/orders#order-reference-generating)
+
 ## 2.0-beta13.2
 
 ### Changes to modifiers - High Impact

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Saved carts have been removed from the core
 - Removed macro functionality from the `BaseModel` into it's own trait.
 - The `last_four` column on transactions is now nullable.
+- The `override` method for Order reference generators has been removed in favour of a config based approach.
 
 ## 2.0-beta13 - 2022-05-19
 

--- a/packages/core/config/orders.php
+++ b/packages/core/config/orders.php
@@ -1,6 +1,18 @@
 <?php
 
+use GetCandy\Base\OrderReferenceGenerator;
+
 return [
+    /*
+    |--------------------------------------------------------------------------
+    | Order Reference Generator
+    |--------------------------------------------------------------------------
+    |
+    | Here you can specify how you want your order references to be generated
+    | when you create an order from a cart.
+    |
+    */
+    'reference_generator' => OrderReferenceGenerator::class,
     /*
     |--------------------------------------------------------------------------
     | Draft Status

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -4,7 +4,6 @@ namespace GetCandy\Actions\Carts;
 
 use GetCandy\Actions\Orders\GenerateOrderReference;
 use GetCandy\Base\OrderModifiers;
-use GetCandy\Base\OrderReferenceGenerator;
 use GetCandy\DataTypes\ShippingOption;
 use GetCandy\Models\Cart;
 use GetCandy\Models\Currency;

--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -2,8 +2,9 @@
 
 namespace GetCandy\Actions\Carts;
 
+use GetCandy\Actions\Orders\GenerateOrderReference;
 use GetCandy\Base\OrderModifiers;
-use GetCandy\Base\OrderReferenceGeneratorInterface;
+use GetCandy\Base\OrderReferenceGenerator;
 use GetCandy\DataTypes\ShippingOption;
 use GetCandy\Models\Cart;
 use GetCandy\Models\Currency;
@@ -13,13 +14,6 @@ use Illuminate\Support\Facades\DB;
 
 class CreateOrder
 {
-    protected $referenceGenerator;
-
-    public function __construct(OrderReferenceGeneratorInterface $generator)
-    {
-        $this->referenceGenerator = $generator;
-    }
-
     /**
      * Execute the action.
      *
@@ -68,7 +62,7 @@ class CreateOrder
             ]);
 
             $order->update([
-                'reference' => $this->referenceGenerator->generate($order),
+                'reference' => app(GenerateOrderReference::class)->execute($order),
             ]);
 
             $orderLines = $cart->lines->map(function ($line) {

--- a/packages/core/src/Actions/Orders/GenerateOrderReference.php
+++ b/packages/core/src/Actions/Orders/GenerateOrderReference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace GetCandy\Actions\Orders;
+
+use GetCandy\Base\Addressable;
+use GetCandy\DataTypes\Price;
+use GetCandy\Facades\Pricing;
+use GetCandy\Facades\Taxes;
+use GetCandy\Models\CartLine;
+use GetCandy\Models\Order;
+use Illuminate\Support\Collection;
+
+class GenerateOrderReference
+{
+    /**
+     * Execute the action.
+     *
+     * @param  \GetCandy\Models\CartLine  $cartLine
+     * @param  \Illuminate\Database\Eloquent\Collection  $customerGroups
+     * @return \GetCandy\Models\CartLine
+     */
+    public function execute(
+        Order $order
+    ) {
+        $generator = config('getcandy.orders.reference_generator');
+
+        if (!$generator) {
+            return null;
+        }
+
+        return app($generator)->generate($order);
+    }
+}

--- a/packages/core/src/Actions/Orders/GenerateOrderReference.php
+++ b/packages/core/src/Actions/Orders/GenerateOrderReference.php
@@ -2,13 +2,7 @@
 
 namespace GetCandy\Actions\Orders;
 
-use GetCandy\Base\Addressable;
-use GetCandy\DataTypes\Price;
-use GetCandy\Facades\Pricing;
-use GetCandy\Facades\Taxes;
-use GetCandy\Models\CartLine;
 use GetCandy\Models\Order;
-use Illuminate\Support\Collection;
 
 class GenerateOrderReference
 {
@@ -24,7 +18,7 @@ class GenerateOrderReference
     ) {
         $generator = config('getcandy.orders.reference_generator');
 
-        if (!$generator) {
+        if (! $generator) {
             return null;
         }
 

--- a/packages/core/src/Base/OrderReferenceGenerator.php
+++ b/packages/core/src/Base/OrderReferenceGenerator.php
@@ -9,21 +9,10 @@ use Illuminate\Support\Facades\DB;
 class OrderReferenceGenerator implements OrderReferenceGeneratorInterface
 {
     /**
-     * The override generator.
-     *
-     * @var \Closure
-     */
-    protected ?Closure $overrideCallback = null;
-
-    /**
      * {@inheritDoc}
      */
     public function generate(Order $order): string
     {
-        if ($this->overrideCallback) {
-            return call_user_func($this->overrideCallback, $order);
-        }
-
         $year = $order->created_at->year;
 
         $month = $order->created_at->format('m');
@@ -48,18 +37,5 @@ class OrderReferenceGenerator implements OrderReferenceGeneratorInterface
         }
 
         return $year.'-'.$month.'-'.str_pad($increment, 4, 0, STR_PAD_LEFT);
-    }
-
-    /**
-     * Override the current method of generating a reference.
-     *
-     * @param  Closure  $callback
-     * @return self
-     */
-    public function override(Closure $callback)
-    {
-        $this->overrideCallback = $callback;
-
-        return $this;
     }
 }

--- a/packages/core/src/Base/OrderReferenceGenerator.php
+++ b/packages/core/src/Base/OrderReferenceGenerator.php
@@ -2,7 +2,6 @@
 
 namespace GetCandy\Base;
 
-use Closure;
 use GetCandy\Models\Order;
 use Illuminate\Support\Facades\DB;
 

--- a/packages/core/src/GetCandyServiceProvider.php
+++ b/packages/core/src/GetCandyServiceProvider.php
@@ -12,8 +12,6 @@ use GetCandy\Base\CartSessionInterface;
 use GetCandy\Base\FieldTypeManifest;
 use GetCandy\Base\FieldTypeManifestInterface;
 use GetCandy\Base\OrderModifiers;
-use GetCandy\Base\OrderReferenceGenerator;
-use GetCandy\Base\OrderReferenceGeneratorInterface;
 use GetCandy\Base\PaymentManagerInterface;
 use GetCandy\Base\PricingManagerInterface;
 use GetCandy\Base\ShippingManifest;
@@ -116,10 +114,6 @@ class GetCandyServiceProvider extends ServiceProvider
 
         $this->app->singleton(ShippingManifestInterface::class, function ($app) {
             return $app->make(ShippingManifest::class);
-        });
-
-        $this->app->singleton(OrderReferenceGeneratorInterface::class, function ($app) {
-            return $app->make(OrderReferenceGenerator::class);
         });
 
         $this->app->singleton(AttributeManifestInterface::class, function ($app) {

--- a/packages/core/tests/Stubs/TestOrderReferenceGenerator.php
+++ b/packages/core/tests/Stubs/TestOrderReferenceGenerator.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace GetCandy\Tests\Stubs;
+
+use GetCandy\Base\OrderReferenceGeneratorInterface;
+use GetCandy\Models\Order;
+
+class TestOrderReferenceGenerator implements OrderReferenceGeneratorInterface
+{
+    /**
+     * Called just after cart totals are calculated.
+     *
+     * @return void
+     */
+    public function generate(Order $order): string
+    {
+        return 'reference-' . $order->id;
+    }
+}

--- a/packages/core/tests/Stubs/TestOrderReferenceGenerator.php
+++ b/packages/core/tests/Stubs/TestOrderReferenceGenerator.php
@@ -14,6 +14,6 @@ class TestOrderReferenceGenerator implements OrderReferenceGeneratorInterface
      */
     public function generate(Order $order): string
     {
-        return 'reference-' . $order->id;
+        return 'reference-'.$order->id;
     }
 }

--- a/packages/core/tests/Unit/Actions/Orders/GenerateOrderReferenceTest.php
+++ b/packages/core/tests/Unit/Actions/Orders/GenerateOrderReferenceTest.php
@@ -62,7 +62,7 @@ class SortProductsByPriceTest extends TestCase
 
         $result = app(GenerateOrderReference::class)->execute($order);
 
-        $this->assertEquals('reference-' . $order->id, $result);
+        $this->assertEquals('reference-'.$order->id, $result);
     }
 
     /** @test */


### PR DESCRIPTION
This PR looks to move the Generator for Order references out of a callback approach and into the config files to be more in line with how this will be in future releases.