### PR TITLE
Hotfix - Tweak to index meta on customers info by default

### DIFF
--- a/packages/core/src/Models/Customer.php
+++ b/packages/core/src/Models/Customer.php
@@ -81,7 +81,7 @@ class Customer extends BaseModel
      */
     public function getSearchableAttributes()
     {
-        $metaFields = config('getcandy-hub.customers.searchable_meta', []);
+        $metaFields = (array) $this->meta;
 
         $data = [
             'id'           => $this->id,
@@ -90,8 +90,8 @@ class Customer extends BaseModel
             'vat_no'       => $this->vat_no,
         ];
 
-        foreach ($metaFields as $field) {
-            $data[$field] = optional($this->meta)->{$field};
+        foreach ($metaFields as $key => $value) {
+            $data[$key] = $value;
         }
 
         foreach ($this->attribute_data ?? [] as $field => $value) {


### PR DESCRIPTION
Currently searching on customer meta values is opt in, this can lead to data being missed on the index and lead to a poor UX and for no real good reason. This PR looks to index the search meta automatically.