### PR TITLE
Hotfix - Introduce a toggle when deleting collection group

### DIFF
--- a/packages/admin/resources/lang/en/catalogue.php
+++ b/packages/admin/resources/lang/en/catalogue.php
@@ -13,6 +13,7 @@ return [
     'collections.groups.delete.title'            => 'Delete collection group',
     'collections.groups.delete.strapline'        => 'Are you sure you want to delete this collection group?',
     'collections.groups.delete.warning'          => 'All collections within this group will also be removed.',
+    'collections.groups.delete.confirm'          => 'Confirm you want to delete the collection groupa all associated collections',
     'collections.groups.delete.btn'              => 'Delete collection group',
     'collections.groups.move.title'              => 'Move Collection',
     'collections.groups.move.search_placeholder' => 'Search for a collection to use for parent',

--- a/packages/admin/resources/views/components/alert.blade.php
+++ b/packages/admin/resources/views/components/alert.blade.php
@@ -25,8 +25,8 @@
         @endswitch
       </div>
     </div>
-    <div class="flex-1 ml-3 md:flex md:justify-between">
-      <p
+    <div class="flex-1 ml-3 md:flex md:justify-between w-full">
+      <div
         @class([
           'text-sm',
           'text-yellow-700' => $level == 'warning',
@@ -35,7 +35,7 @@
         ])
       >
         {{ $slot }}
-      </p>
+      </div>
     </div>
   </div>
 </div>

--- a/packages/admin/resources/views/livewire/components/collections/collection-groups/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/collections/collection-groups/show.blade.php
@@ -41,12 +41,18 @@
             <x-hub::modal.dialog wire:model="showDeleteConfirm"
                                  form="deleteGroup">
                 <x-slot name="title">
-                    {{ __('adminhub::catalogue.collections.groups.delete.title') }}
+                  {{ __('adminhub::catalogue.collections.groups.delete.strapline') }}
                 </x-slot>
                 <x-slot name="content">
-                    <p>{{ __('adminhub::catalogue.collections.groups.delete.strapline') }}
-                    <p>
-                    <p>{{ __('adminhub::catalogue.collections.groups.delete.warning') }}</p>
+                  <div class="space-y-4">
+                    <x-hub::alert level="danger">
+                      {{ __('adminhub::catalogue.collections.groups.delete.warning') }}
+                    </x-hub::alert>
+
+                    <x-hub::input.group :label="__('adminhub::catalogue.collections.groups.delete.confirm')" for="confirmation">
+                      <x-hub::input.toggle wire:model="deletionConfirm" id="confirmation" />
+                    </x-hub::input.group>
+                  </div>
                 </x-slot>
                 <x-slot name="footer">
                     <x-hub::button type="button"
@@ -55,7 +61,8 @@
                         {{ __('adminhub::global.cancel') }}
                     </x-hub::button>
                     <x-hub::button type="submit"
-                                   theme="danger">
+                                   theme="danger"
+                                   :disabled="!$deletionConfirm">
                         {{ __('adminhub::catalogue.collections.groups.delete.btn') }}
                     </x-hub::button>
                 </x-slot>

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
@@ -36,7 +36,14 @@ class CollectionGroupShow extends Component
      *
      * @var bool
      */
-    public bool $showDeleteConfirm = false;
+    public bool $showDeleteConfirm = true;
+
+    /**
+     * Failsafe confirmation in order to delete the collection group.
+     *
+     * @var bool
+     */
+    public bool $deletionConfirm = false;
 
     /**
      * The ID of the collection we want to remove.
@@ -104,6 +111,7 @@ class CollectionGroupShow extends Component
         $rules = [
             'group.name'      => 'required|string|max:255|unique:'.CollectionGroup::class.',name,'.$this->group->id,
             'collection.name' => 'required|string|max:255',
+            'deletionConfirm' => 'nullable|boolean',
         ];
 
         if ($this->slugIsRequired) {
@@ -144,6 +152,16 @@ class CollectionGroupShow extends Component
         $this->group->handle = Str::slug($this->group->name);
         $this->group->save();
         $this->notify(__('adminhub::notifications.collection-groups.updated'));
+    }
+
+    /**
+     * Watcher for when the show delete confirm is updated.
+     *
+     * @return void
+     */
+    public function updatedShowDeleteConfirm()
+    {
+        $this->deletionConfirm = false;
     }
 
     /**


### PR DESCRIPTION
When removing a collection group it's quite destructive and although there is a modal to confirm, there should really be an additional step to make double sure.

This PR adds an additional toggle the user has to check in order to enable the delete button.