### PR TITLE
Hotfix - Refresh tree when node is created

### DIFF
--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionGroupShow.php
@@ -429,7 +429,9 @@ class CollectionGroupShow extends Component
 
         $this->showCreateForm = false;
 
-        $this->emit('collectionsChanged', $collection->parent_id);
+        $this->loadTree();
+
+        $this->emit('refreshTree', $this->tree);
 
         $this->notify(
             __('adminhub::notifications.collections.added')

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
@@ -38,6 +38,7 @@ class CollectionTree extends Component
     protected $listeners = [
         'collectionMoved',
         'collectionsChanged',
+        'refreshTree',
     ];
 
     /**
@@ -181,6 +182,18 @@ class CollectionTree extends Component
                 Collection::whereParentId($nodeMatched['parent_id'])->withCount('children')->defaultOrder()->get()
             );
         }
+    }
+
+    /**
+     * Refresh the tree with a new set of nodes.
+     *
+     * @param array $nodes
+     *
+     * @return void
+     */
+    public function refreshTree(array $nodes)
+    {
+        $this->nodes = $nodes;
     }
 
     /**

--- a/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
+++ b/packages/admin/src/Http/Livewire/Components/Collections/CollectionTree.php
@@ -187,8 +187,7 @@ class CollectionTree extends Component
     /**
      * Refresh the tree with a new set of nodes.
      *
-     * @param array $nodes
-     *
+     * @param  array  $nodes
      * @return void
      */
     public function refreshTree(array $nodes)


### PR DESCRIPTION
Closes #425 