### PR TITLE
Make sure the correct attributes show when changing product type

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - When variants are disabled, editing a product type will not longer display tabs for variant attributes.
 - Fixed an issue where adding a comment to the activity log would error.
 - Comments should now show correctly on product editing pages.
+- Fixed an issue where incorrect attributes were showing when changing product types
 
 ### 2.0-beta14 - 2022-08-03
 

--- a/packages/admin/resources/views/partials/attributes.blade.php
+++ b/packages/admin/resources/views/partials/attributes.blade.php
@@ -9,7 +9,7 @@
         </header>
         <div class="space-y-4">
           @foreach($group['fields'] as $attIndex => $field)
-            <div wire:key="{{ $field['handle'] }}">
+            <div wire:key="attributes_{{ $field['handle'] }}">
               <x-hub::input.group
                 :label="$field['name']"
                 :for="$field['handle']"

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -735,7 +735,13 @@ abstract class AbstractProduct extends Component
      */
     public function getVariantAttributeGroupsProperty()
     {
-        $groupIds = $this->variantAttributes->pluck('group_id')->unique();
+        $groupIds = $this->availableVariantAttributes->pluck('attribute_group_id')->unique();
+        
+        $this->variantAttributes = $this->parseAttributes(
+            $this->availableVariantAttributes,
+            $this->variant->attribute_data,
+            'variantAttributes',
+        );
 
         return AttributeGroup::whereIn('id', $groupIds)
             ->orderBy('position')

--- a/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/AbstractProduct.php
@@ -735,13 +735,7 @@ abstract class AbstractProduct extends Component
      */
     public function getVariantAttributeGroupsProperty()
     {
-        $groupIds = $this->availableVariantAttributes->pluck('attribute_group_id')->unique();
-        
-        $this->variantAttributes = $this->parseAttributes(
-            $this->availableVariantAttributes,
-            $this->variant->attribute_data,
-            'variantAttributes',
-        );
+        $groupIds = $this->variantAttributes->pluck('group_id')->unique();
 
         return AttributeGroup::whereIn('id', $groupIds)
             ->orderBy('position')

--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -36,6 +36,12 @@ trait WithAttributes
     public function updatedProductProductTypeId()
     {
         $this->mapAttributes();
+        
+        $this->variantAttributes = $this->parseAttributes(
+            $this->availableVariantAttributes,
+            $this->variantAttributes,
+            'variantAttributes',
+        );
     }
 
     protected function mapAttributes()

--- a/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
+++ b/packages/admin/src/Http/Livewire/Traits/WithAttributes.php
@@ -36,7 +36,7 @@ trait WithAttributes
     public function updatedProductProductTypeId()
     {
         $this->mapAttributes();
-        
+
         $this->variantAttributes = $this->parseAttributes(
             $this->availableVariantAttributes,
             $this->variantAttributes,


### PR DESCRIPTION
When changing the product type on a product that only had 1 variant the attribute fields were not updating correctly as `$this-> variantAttributes` was only set on mount().

This PR updates the logic to ensure the right attributes are parsed.
