### PR TITLE
Hotfix - Fix activity log comments

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -3,6 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### [Unreleased]
+
+## Fixed
+
+- Fixed an issue where adding a comment to the activity log would error.
+- Comments should now show correctly on product editing pages.
+
 ### 2.0-beta14 - 2022-08-03
 
 ## Changed

--- a/packages/admin/src/Base/ActivityLog/Manifest.php
+++ b/packages/admin/src/Base/ActivityLog/Manifest.php
@@ -7,6 +7,7 @@ use GetCandy\Hub\Base\ActivityLog\Orders\EmailNotification;
 use GetCandy\Hub\Base\ActivityLog\Orders\Intent;
 use GetCandy\Hub\Base\ActivityLog\Orders\StatusUpdate;
 use GetCandy\Models\Order;
+use GetCandy\Models\Product;
 use Illuminate\Support\Collection;
 
 class Manifest
@@ -23,6 +24,9 @@ class Manifest
             Capture::class,
             Intent::class,
             EmailNotification::class,
+        ],
+        Product::class => [
+            Comment::class,
         ],
     ];
 

--- a/packages/admin/src/Http/Livewire/Components/ActivityLogFeed.php
+++ b/packages/admin/src/Http/Livewire/Components/ActivityLogFeed.php
@@ -3,14 +3,14 @@
 namespace GetCandy\Hub\Http\Livewire\Components;
 
 use GetCandy\Hub\Facades\ActivityLog;
+use GetCandy\Hub\Http\Livewire\Traits\Notifies;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Livewire\WithPagination;
-use Spatie\Activitylog\Models\Activity;
 
 class ActivityLogFeed extends Component
 {
-    use WithPagination;
+    use WithPagination, Notifies;
 
     /**
      * The log subject to get activity for.
@@ -18,6 +18,46 @@ class ActivityLogFeed extends Component
      * @var \Illuminate\Database\Eloquent\Model
      */
     public Model $subject;
+
+    /**
+     * The new comment for the subject.
+     *
+     * @var string|null
+     */
+    public ?string $comment = null;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function rules()
+    {
+        return [
+            'comment' => 'string|required',
+        ];
+    }
+
+    /**
+     * Add a comment to the order.
+     *
+     * @return void
+     */
+    public function addComment()
+    {
+        activity()
+            ->performedOn($this->subject)
+            ->causedBy(
+                auth()->user()
+            )
+            ->event('comment')
+            ->withProperties(['content' => $this->comment])
+            ->log('comment');
+
+        $this->notify(
+            __('adminhub::notifications.order.comment_added')
+        );
+
+        $this->comment = null;
+    }
 
     /**
      * Returns the activity log for the order.

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
@@ -535,29 +535,6 @@ class OrderShow extends Component
     }
 
     /**
-     * Add a comment to the order.
-     *
-     * @return void
-     */
-    public function addComment()
-    {
-        activity()
-            ->performedOn($this->order)
-            ->causedBy(
-                auth()->user()
-            )
-            ->event('comment')
-            ->withProperties(['content' => $this->comment])
-            ->log('comment');
-
-        $this->notify(
-            __('adminhub::notifications.order.comment_added')
-        );
-
-        $this->comment = '';
-    }
-
-    /**
      * Render the livewire component.
      *
      * @return \Illuminate\View\View

--- a/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
@@ -2,17 +2,13 @@
 
 namespace GetCandy\Hub\Tests\Unit\Http\Livewire\Components;
 
-use GetCandy\Hub\Http\Livewire\Components\Account;
 use GetCandy\Hub\Http\Livewire\Components\ActivityLogFeed;
 use GetCandy\Hub\Models\Staff;
 use GetCandy\Hub\Tests\TestCase;
-use GetCandy\Models\Country;
 use GetCandy\Models\Currency;
 use GetCandy\Models\Language;
 use GetCandy\Models\Order;
-use GetCandy\Models\OrderAddress;
 use Illuminate\Foundation\Testing\RefreshDatabase;
-use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
 use Spatie\Activitylog\Models\Activity;
 
@@ -58,7 +54,6 @@ class ActivityLogFeedTest extends TestCase
             'admin' => true,
         ]);
 
-
         Livewire::actingAs($staff, 'staff')->test(ActivityLogFeed::class, [
             'subject' => $order,
         ]);
@@ -83,7 +78,6 @@ class ActivityLogFeedTest extends TestCase
         $staff = Staff::factory()->create([
             'admin' => true,
         ]);
-
 
         Livewire::actingAs($staff, 'staff')->test(ActivityLogFeed::class, [
             'subject' => $order,

--- a/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/ActivityLogFeedTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace GetCandy\Hub\Tests\Unit\Http\Livewire\Components;
+
+use GetCandy\Hub\Http\Livewire\Components\Account;
+use GetCandy\Hub\Http\Livewire\Components\ActivityLogFeed;
+use GetCandy\Hub\Models\Staff;
+use GetCandy\Hub\Tests\TestCase;
+use GetCandy\Models\Country;
+use GetCandy\Models\Currency;
+use GetCandy\Models\Language;
+use GetCandy\Models\Order;
+use GetCandy\Models\OrderAddress;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * @group hub.activity-log
+ */
+class ActivityLogFeedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        Language::factory()->create([
+            'default' => true,
+            'code'    => 'en',
+        ]);
+
+        Currency::factory()->create([
+            'default'        => true,
+            'decimal_places' => 2,
+        ]);
+    }
+
+    /** @test */
+    public function can_mount_component()
+    {
+        $order = Order::factory()->create([
+            'user_id'   => null,
+            'placed_at' => now(),
+            'status' => 'awaiting-payment',
+            'currency_code' => Currency::getDefault()->code,
+            'meta'      => [
+                'foo' => 'bar',
+            ],
+            'tax_breakdown' => [
+                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
+            ],
+        ]);
+
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+
+        Livewire::actingAs($staff, 'staff')->test(ActivityLogFeed::class, [
+            'subject' => $order,
+        ]);
+    }
+
+    /** @test */
+    public function can_add_comment()
+    {
+        $order = Order::factory()->create([
+            'user_id'   => null,
+            'placed_at' => now(),
+            'status' => 'awaiting-payment',
+            'currency_code' => Currency::getDefault()->code,
+            'meta'      => [
+                'foo' => 'bar',
+            ],
+            'tax_breakdown' => [
+                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
+            ],
+        ]);
+
+        $staff = Staff::factory()->create([
+            'admin' => true,
+        ]);
+
+
+        Livewire::actingAs($staff, 'staff')->test(ActivityLogFeed::class, [
+            'subject' => $order,
+        ])->set('comment', 'Testing 123')
+            ->call('addComment')
+            ->assertHasNoErrors()
+            ->assertSet('comment', null)
+            ->assertSee('Testing 123');
+
+        $this->assertDatabaseHas((new Activity())->getTable(), [
+            'event' => 'comment',
+            'subject_id' => $order->id,
+            'subject_type' => Order::class,
+            'causer_id' => $staff->id,
+            'properties' => json_encode([
+                'content' => 'Testing 123',
+            ]),
+        ]);
+    }
+}

--- a/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderShowTest.php
+++ b/packages/admin/tests/Unit/Http/Livewire/Components/Orders/OrderShowTest.php
@@ -122,53 +122,6 @@ class OrderShowTest extends TestCase
     }
 
     /** @test */
-    public function can_add_comment()
-    {
-        $staff = Staff::factory()->create([
-            'admin' => true,
-        ]);
-
-        $order = Order::factory()->create([
-            'user_id'   => null,
-            'placed_at' => now(),
-            'status' => 'awaiting-payment',
-            'currency_code' => Currency::getDefault()->code,
-            'meta'      => [
-                'foo' => 'bar',
-            ],
-            'tax_breakdown' => [
-                ['description' => 'VAT', 'percentage' => 20, 'total' => 200],
-            ],
-        ]);
-
-        $this->assertCount(0, $order->lines);
-
-        OrderLine::factory()->create([
-            'purchasable_type' => ProductVariant::class,
-            'purchasable_id'   => ProductVariant::factory()->create()->id,
-            'order_id' => $order->id,
-        ]);
-
-        LiveWire::actingAs($staff, 'staff')
-        ->test(OrderShow::class, [
-            'order' => $order,
-        ])->assertSet('order.status', $order->status)
-        ->set('comment', 'Testing 123')
-        ->call('addComment')
-        ->assertHasNoErrors();
-
-        $this->assertDatabaseHas((new Activity)->getTable(), [
-            'event' => 'comment',
-            'subject_id' => $order->id,
-            'subject_type' => Order::class,
-            'causer_id' => $staff->id,
-            'properties' => json_encode([
-                'content' => 'Testing 123',
-            ]),
-        ]);
-    }
-
-    /** @test */
     public function billing_address_visibility_is_correct()
     {
         $staff = Staff::factory()->create([


### PR DESCRIPTION
Currently there is an error when trying to add comments to the activity log. This PR looks to fix this.

Also comments weren't appearing on the product editing activity log, this should also be fixed.