### PR TITLE
Hotfix - Remove tabs if variants are disabled.

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -3,6 +3,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### [Unreleased]
+
+## Fixed
+
+- When variants are disabled, editing a product type will not longer display tabs for variant attributes.
+
 ### 2.0-beta14 - 2022-08-03
 
 ## Changed

--- a/packages/admin/resources/views/partials/forms/product-type.blade.php
+++ b/packages/admin/resources/views/partials/forms/product-type.blade.php
@@ -6,20 +6,22 @@
     </div>
 
     <div x-data="{ view: 'products' }">
-      <nav class="flex space-x-4" aria-label="Tabs">
-        <!-- Current: "bg-gray-100 text-gray-700", Default: "text-gray-500 hover:text-gray-700" -->
-        <button type="button" wire:click="$set('view', 'products')" class="px-3 py-3 text-sm font-medium @if($view == 'products') text-gray-800 bg-white @else test-gray-500 hover:text-gray-700 @endif rounded-t">
-            {{ __('adminhub::partials.product-type.product_attributes_btn') }}
-        </button>
+      @if(!$this->variantsDisabled)
+        <nav class="flex space-x-4" aria-label="Tabs">
+          <!-- Current: "bg-gray-100 text-gray-700", Default: "text-gray-500 hover:text-gray-700" -->
+          <button type="button" wire:click="$set('view', 'products')" class="px-3 py-3 text-sm font-medium @if($view == 'products') text-gray-800 bg-white @else test-gray-500 hover:text-gray-700 @endif rounded-t">
+              {{ __('adminhub::partials.product-type.product_attributes_btn') }}
+          </button>
 
-        <button
-          type="button"
-          wire:click="$set('view', 'variants')"
-          class="px-3 py-3 text-sm font-medium @if($view == 'variants') text-gray-800 bg-white @else test-gray-500 hover:text-gray-700 @endif rounded-t"
-        >
-        {{ __('adminhub::partials.product-type.variant_attributes_btn') }}
-        </button>
-      </nav>
+          <button
+            type="button"
+            wire:click="$set('view', 'variants')"
+            class="px-3 py-3 text-sm font-medium @if($view == 'variants') text-gray-800 bg-white @else test-gray-500 hover:text-gray-700 @endif rounded-t"
+          >
+          {{ __('adminhub::partials.product-type.variant_attributes_btn') }}
+          </button>
+        </nav>
+      @endif
 
       <div class="p-6 bg-white rounded-b shadow">
         @if($view == 'products')

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/AbstractProductType.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/AbstractProductType.php
@@ -86,6 +86,16 @@ abstract class AbstractProductType extends Component
     }
 
     /**
+     * Return whether variants are disabled.
+     *
+     * @return bool
+     */
+    public function getVariantsDisabledProperty()
+    {
+        return config('getcandy-hub.products.disable_variants', false);
+    }
+
+    /**
      * Return attributes for a group.
      *
      * @param  string|int  $groupId

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
@@ -71,16 +71,6 @@ class ProductTypeShow extends AbstractProductType
     }
 
     /**
-     * Return whether variants are disabled.
-     *
-     * @return bool
-     */
-    public function getVariantsDisabledProperty()
-    {
-        return config('getcandy-hub.products.disable_variants', false);
-    }
-
-    /**
      * Returns whether this is the only Product type in the system.
      *
      * @return bool

--- a/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Products/ProductTypes/ProductTypeShow.php
@@ -71,6 +71,16 @@ class ProductTypeShow extends AbstractProductType
     }
 
     /**
+     * Return whether variants are disabled.
+     *
+     * @return bool
+     */
+    public function getVariantsDisabledProperty()
+    {
+        return config('getcandy-hub.products.disable_variants', false);
+    }
+
+    /**
      * Returns whether this is the only Product type in the system.
      *
      * @return bool


### PR DESCRIPTION
Currently when editing a product type the variant attributes tab will be visible even if they are disabled. This PR removes these tabs when they are disabled, creating a better UX.