### PR TITLE
`Blink` default queries to avoid multiple database calls

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "livewire/livewire": "^2.0",
         "php": "^8.0",
         "spatie/laravel-activitylog": "^4.4",
-        "spatie/laravel-blink": "^1.6.*",
+        "spatie/laravel-blink": "^1.6",
         "spatie/laravel-medialibrary": "^9.0.0|^10.0.0",
         "yab/laravel-scout-mysql-driver": "^5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "livewire/livewire": "^2.0",
         "php": "^8.0",
         "spatie/laravel-activitylog": "^4.4",
+        "spatie/laravel-blink": "^1.6.*",
         "spatie/laravel-medialibrary": "^9.0.0|^10.0.0",
         "yab/laravel-scout-mysql-driver": "^5.0"
     },

--- a/packages/admin/tests/TestCase.php
+++ b/packages/admin/tests/TestCase.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\View;
 use Kalnoy\Nestedset\NestedSetServiceProvider;
 use Livewire\LivewireServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
+use Spatie\LaravelBlink\BlinkServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -37,6 +38,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             MediaLibraryServiceProvider::class,
             ConverterServiceProvider::class,
             NestedSetServiceProvider::class,
+            BlinkServiceProvider::class,
         ];
     }
 

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -38,6 +38,7 @@
         "laravel/framework": "^8.0|^9.0",
         "spatie/laravel-medialibrary": "^9.0.0|^10.0.0",
         "spatie/laravel-activitylog": "^4.4",
+        "spatie/laravel-blink": "^1.6.*",
         "laravel/scout": "^9.4",
         "cartalyst/converter": "^6.1|^7.0",
         "yab/laravel-scout-mysql-driver": "^5.0",

--- a/packages/core/composer.json
+++ b/packages/core/composer.json
@@ -38,12 +38,12 @@
         "laravel/framework": "^8.0|^9.0",
         "spatie/laravel-medialibrary": "^9.0.0|^10.0.0",
         "spatie/laravel-activitylog": "^4.4",
-        "spatie/laravel-blink": "^1.6.*",
         "laravel/scout": "^9.4",
         "cartalyst/converter": "^6.1|^7.0",
         "yab/laravel-scout-mysql-driver": "^5.0",
         "kalnoy/nestedset": "^6.0",
-        "doctrine/dbal": "3.3.7"
+        "doctrine/dbal": "3.3.7",
+        "spatie/laravel-blink": "^1.6"
     },
     "require-dev": {
         "orchestra/testbench": "^6.0|^7.0",

--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -2,6 +2,9 @@
 
 namespace GetCandy\Base\Traits;
 
+use Illuminate\Support\Str;
+use Spatie\LaravelBlink\BlinkFacade as Blink;
+
 trait HasDefaultRecord
 {
     /**
@@ -22,6 +25,9 @@ trait HasDefaultRecord
      */
     public static function getDefault()
     {
-        return self::query()->default(true)->first();
+        $key = 'getcandy_default_'.Str::snake(self::class);
+        return Blink::once($key, function() {
+            return self::query()->default(true)->first();
+        });
     }
 }

--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -3,7 +3,7 @@
 namespace GetCandy\Base\Traits;
 
 use Illuminate\Support\Str;
-use Spatie\LaravelBlink\BlinkFacade as Blink;
+use Spatie\Blink\Blink;
 
 trait HasDefaultRecord
 {
@@ -27,7 +27,7 @@ trait HasDefaultRecord
     {
         $key = 'getcandy_default_'.Str::snake(self::class);
 
-        return Blink::once($key, function () {
+        return (new Blink)->once($key, function () {
             return self::query()->default(true)->first();
         });
     }

--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -26,7 +26,8 @@ trait HasDefaultRecord
     public static function getDefault()
     {
         $key = 'getcandy_default_'.Str::snake(self::class);
-        return Blink::once($key, function() {
+
+        return Blink::once($key, function () {
             return self::query()->default(true)->first();
         });
     }

--- a/packages/core/src/Base/Traits/HasDefaultRecord.php
+++ b/packages/core/src/Base/Traits/HasDefaultRecord.php
@@ -3,7 +3,7 @@
 namespace GetCandy\Base\Traits;
 
 use Illuminate\Support\Str;
-use Spatie\Blink\Blink;
+use Spatie\LaravelBlink\BlinkFacade as Blink;
 
 trait HasDefaultRecord
 {
@@ -27,7 +27,7 @@ trait HasDefaultRecord
     {
         $key = 'getcandy_default_'.Str::snake(self::class);
 
-        return (new Blink)->once($key, function () {
+        return Blink::once($key, function () {
             return self::query()->default(true)->first();
         });
     }

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -28,11 +28,9 @@ class CartSessionManager implements CartSessionInterface
      */
     public function current()
     {
-        return Blink::once('getcandy_current_cart', function () {
-            return $this->fetchOrCreate(
-                config('getcandy.cart.auto_create', false)
-            );
-        });
+        return $this->fetchOrCreate(
+            config('getcandy.cart.auto_create', false)
+        );
     }
 
     /**
@@ -40,7 +38,6 @@ class CartSessionManager implements CartSessionInterface
      */
     public function forget()
     {
-        Blink::forget('getcandy_current_cart');
         $this->sessionManager->forget(
             $this->getSessionKey()
         );

--- a/packages/core/src/Managers/CartSessionManager.php
+++ b/packages/core/src/Managers/CartSessionManager.php
@@ -28,9 +28,11 @@ class CartSessionManager implements CartSessionInterface
      */
     public function current()
     {
-        return $this->fetchOrCreate(
-            config('getcandy.cart.auto_create', false)
-        );
+        return Blink::once('getcandy_current_cart', function () {
+            return $this->fetchOrCreate(
+                config('getcandy.cart.auto_create', false)
+            );
+        });
     }
 
     /**
@@ -38,6 +40,7 @@ class CartSessionManager implements CartSessionInterface
      */
     public function forget()
     {
+        Blink::forget('getcandy_current_cart');
         $this->sessionManager->forget(
             $this->getSessionKey()
         );

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -11,7 +11,6 @@ use Kalnoy\Nestedset\NestedSetServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
 use Spatie\LaravelBlink\BlinkServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
-use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
 {

--- a/packages/core/tests/TestCase.php
+++ b/packages/core/tests/TestCase.php
@@ -9,6 +9,8 @@ use GetCandy\Tests\Stubs\User;
 use Illuminate\Support\Facades\Config;
 use Kalnoy\Nestedset\NestedSetServiceProvider;
 use Spatie\Activitylog\ActivitylogServiceProvider;
+use Spatie\LaravelBlink\BlinkServiceProvider;
+use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 
 class TestCase extends \Orchestra\Testbench\TestCase
@@ -30,6 +32,7 @@ class TestCase extends \Orchestra\Testbench\TestCase
             ActivitylogServiceProvider::class,
             ConverterServiceProvider::class,
             NestedSetServiceProvider::class,
+            BlinkServiceProvider::class,
         ];
     }
 


### PR DESCRIPTION
This PR adds `spatie/laravel-blink` as a dependency to the core project and uses it to store any defaults (eg currency, channels) for the lifecycle of the request.

On our test homepage this has removed 80 duplicate queries - which as you can imagine is a lot :)

There are definitely other areas this could be applied to, such as the CartSession manager methods, but this is a good start for now.