### PR TITLE
Fixed type on set_last_four_nullable_on_transactions migration

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+### [ Unreleased ]
+## Fixed
+- When migrating fresh, the transaction table migrations were out of order.  Changed the type when making nullable.
+
 ### 2.0-beta15 - 2022-08-10
 
 ## Changed
@@ -16,7 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Comments should now show correctly on product editing pages.
 - Sortable is now attached to the browser window so it's globally available.
 - Fixed an issue where incorrect attributes were showing when changing product types
-- `doctrine/dbal` locked to `3.3.7` due to issue with Sqlite
+- `doctrine/dbal` locked to `3.3.7` due to issue with Sqlite 
 
 ### 2.0-beta14 - 2022-08-03
 

--- a/packages/core/database/migrations/2022_07_15_100000_set_last_four_to_nullable_on_transactions.php
+++ b/packages/core/database/migrations/2022_07_15_100000_set_last_four_to_nullable_on_transactions.php
@@ -9,14 +9,14 @@ class SetLastFourToNullableOnTransactions extends Migration
     public function up()
     {
         Schema::table($this->prefix.'transactions', function (Blueprint $table) {
-            $table->smallInteger('last_four')->nullable()->change();
+            $table->string('last_four')->nullable()->change();
         });
     }
 
     public function down()
     {
         Schema::table($this->prefix.'transactions', function ($table) {
-            $table->smallInteger('last_four')->nullable(false)->change();
+            $table->string('last_four')->nullable(false)->change();
         });
     }
 }


### PR DESCRIPTION
Fixes issue #482 
Updated the type in `packages/core/database/migrations/2022_07_15_100000_set_last_four_to_nullable_on_transactions.php` to reflect the type that it actually is after all of the other migrations have been run.

Steps to test:
1. Create a test application (laravel9, postgres 14+)
2. Import this version of getcandy as a @dev version.
3. `php artisan vendor:publish --tag=getcandy-migrations`
4. `php artisan migrate:fresh` -- fresh "just in case" you already had a copy of it out there.
5. _Observe_ that the migrations complete without issue.