### PR TITLE
Slot should reference $variant not $product

### DIFF
--- a/packages/admin/resources/views/livewire/components/products/variants/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/products/variants/show.blade.php
@@ -177,7 +177,7 @@
         @foreach ($this->getSlotsByPosition('top') as $slot)
             <div id="{{ $slot->handle }}">
                 <div>
-                    @livewire($slot->component, ['slotModel' => $product], key('top-slot-{{ $slot->handle }}'))
+                    @livewire($slot->component, ['slotModel' => $variant], key('top-slot-{{ $slot->handle }}'))
                 </div>
             </div>
         @endforeach
@@ -199,7 +199,7 @@
         @foreach ($this->getSlotsByPosition('bottom') as $slot)
             <div id="{{ $slot->handle }}">
                 <div>
-                    @livewire($slot->component, ['slotModel' => $product], key('bottom-slot-{{ $slot->handle }}'))
+                    @livewire($slot->component, ['slotModel' => $variant], key('bottom-slot-{{ $slot->handle }}'))
                 </div>
             </div>
         @endforeach


### PR DESCRIPTION
Sorry I missed this when i first committed this change.
The variant slot should pass the variant, not the product.