### PR TITLE
Bugfix - Correcting edit languages anchor lang string

### DIFF
--- a/packages/admin/resources/views/livewire/components/settings/languages/index.blade.php
+++ b/packages/admin/resources/views/livewire/components/settings/languages/index.blade.php
@@ -35,7 +35,7 @@
                     <x-hub::table.cell class="text-right">
                         <a href="{{ route('hub.languages.show', $language->id) }}"
                            class="text-indigo-500 hover:underline">
-                            {{ __('adminhub::settings.staff.index.table_row_action_text') }}
+                            {{ __('adminhub::settings.languages.index.table_row_action_text') }}
                         </a>
                     </x-hub::table.cell>
                 </x-hub::table.row>


### PR DESCRIPTION
Updating languages index page to use correct lang string for edit button
