### PR TITLE
Fix - Fix url management

### DIFF
--- a/packages/admin/CHANGELOG.md
+++ b/packages/admin/CHANGELOG.md
@@ -4,8 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### [ Unreleased ]
+
 ## Fixed
 - When migrating fresh, the transaction table migrations were out of order.  Changed the type when making nullable.
+- Added `wire:key` to URL management
+- When setting a new `default` URL whilst editing, other existing `default` values are set to `false`
 
 ### 2.0-beta15 - 2022-08-10
 

--- a/packages/admin/resources/views/partials/urls.blade.php
+++ b/packages/admin/resources/views/partials/urls.blade.php
@@ -21,7 +21,7 @@
         </div>
       </div>
       @foreach($urls as $url)
-        <div>
+        <div wire:key="url_{{ $url['key'] }}">
           <div class="flex items-center space-x-4" wire:key="url_{{ $loop->index }}">
             <div class="w-64">
               <x-hub::input.select wire:model="urls.{{ $loop->index }}.language_id">

--- a/packages/admin/src/Http/Livewire/Traits/HasUrls.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasUrls.php
@@ -155,7 +155,9 @@ trait HasUrls
 
             foreach ($this->urls as $index => $url) {
                 $urlModel = ($url['id'] ?? false) ? Url::find($url['id']) : new Url();
-                $urlModel->fill($url);
+                $urlModel->default = $url['default'];
+                $urlModel->language_id = $url['language_id'];
+                $urlModel->slug = $url['slug'];
                 $urlModel->element_type = get_class($model);
                 $urlModel->element_id = $model->id;
                 $urlModel->save();

--- a/packages/admin/src/Http/Livewire/Traits/HasUrls.php
+++ b/packages/admin/src/Http/Livewire/Traits/HasUrls.php
@@ -14,7 +14,12 @@ trait HasUrls
 
     public function mountHasUrls()
     {
-        $this->urls = $this->getHasUrlsModel()->urls->toArray();
+        $this->urls = $this->getHasUrlsModel()->urls->map(function ($url) {
+            return array_merge(
+                $url->toArray(),
+                ['key' => $url->id]
+            );
+        })->toArray();
     }
 
     /**
@@ -51,6 +56,7 @@ trait HasUrls
     {
         $this->urls[] = [
             'slug'        => null,
+            'key'         => Str::random(),
             'default'     => ! collect($this->urls)->count(),
             'language_id' => $this->defaultLanguage->id,
         ];
@@ -69,6 +75,18 @@ trait HasUrls
      */
     public function updatedUrls($value, $key)
     {
+        [$index, $field] = explode('.', $key);
+
+        if ($field == 'default' && $value) {
+            // Make sure other defaults are unchecked...
+            $this->urls = collect($this->urls)->map(function ($url, $urlIndex) use ($index) {
+                if ($index != $urlIndex) {
+                    $url['default'] = false;
+                }
+                return $url;
+            })->toArray();
+        }
+
         Arr::set($this->urls, $key, Str::slug($value));
     }
 


### PR DESCRIPTION
Currently there is a couple of quirks with URL management. This aims to solve these:

- Adding a `wire:key` to each row in the url array
- When setting a new default, we should set any other ones to `false` to avoid duplication.