### PR TITLE
Show digital product lines as well as physical ones

### DIFF
--- a/packages/admin/resources/views/livewire/components/orders/show.blade.php
+++ b/packages/admin/resources/views/livewire/components/orders/show.blade.php
@@ -48,7 +48,7 @@
                     </ul>
                 </div>
 
-                @if ($this->physicalLines->count() > $maxLines)
+                @if ($this->physicalAndDigitalLines->count() > $maxLines)
                     <div class="mt-4 text-center">
                         @if (!$allLinesVisible)
                             <div class="relative">
@@ -57,7 +57,7 @@
                                 <div class="relative">
                                     <span class="px-2 text-xs font-medium text-red-600 bg-white">
                                         {{ __('adminhub::components.orders.show.additional_lines_text', [
-                                            'count' => $this->physicalLines->count() - $maxLines,
+                                            'count' => $this->physicalAndDigitalLines->count() - $maxLines,
                                         ]) }}
                                     </span>
                                 </div>

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
@@ -219,7 +219,7 @@ class OrderShow extends Component
      */
     public function getVisibleLinesProperty()
     {
-        return $this->physicalLines->take($this->allLinesVisible ? null : $this->maxLines);
+        return $this->physicalAndDigitalLines->take($this->allLinesVisible ? null : $this->maxLines);
     }
 
     /**
@@ -231,6 +231,18 @@ class OrderShow extends Component
     {
         return $this->order->lines->filter(function ($line) {
             return $line->type == 'physical';
+        });
+    }
+    
+    /**
+     * Return the physical and digital order lines.
+     *
+     * @return void
+     */
+    public function getPhysicalAndDigitalLinesProperty()
+    {
+        return $this->order->lines->filter(function ($line) {
+            return $line->type == 'physical' || $line->type == 'digital';
         });
     }
 

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
@@ -137,7 +137,7 @@ class OrderShow extends Component
             'shippingAddress.delivery_instructions' => 'nullable|string|max:255',
             'shippingAddress.contact_email' => 'nullable|email|max:255',
             'shippingAddress.contact_phone' => 'nullable|string|max:255',
-            'shippingAddress.country_id'   => 'required',
+            'shippingAddress.country_id' => 'required',
             'billingAddress.postcode' => 'required|string|max:255',
             'billingAddress.title' => 'nullable|string|max:255',
             'billingAddress.first_name' => 'nullable|string|max:255',
@@ -151,7 +151,7 @@ class OrderShow extends Component
             'billingAddress.delivery_instructions' => 'nullable|string|max:255',
             'billingAddress.contact_email' => 'nullable|email|max:255',
             'billingAddress.contact_phone' => 'nullable|string|max:255',
-            'billingAddress.country_id'   => 'required',
+            'billingAddress.country_id' => 'required',
         ];
     }
 
@@ -233,7 +233,7 @@ class OrderShow extends Component
             return $line->type == 'physical';
         });
     }
-    
+
     /**
      * Return the physical and digital order lines.
      *

--- a/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
+++ b/packages/admin/src/Http/Livewire/Components/Orders/OrderShow.php
@@ -242,7 +242,7 @@ class OrderShow extends Component
     public function getPhysicalAndDigitalLinesProperty()
     {
         return $this->order->lines->filter(function ($line) {
-            return $line->type == 'physical' || $line->type == 'digital';
+            return in_array($line->type, ['physical', 'digital']);
         });
     }
 


### PR DESCRIPTION
Not sure if this is handled by changes in other PRs, but I noticed that digital products were not being shown in the order view.