### PR TITLE
Change sum to min for getting tax percentage

### DIFF
--- a/packages/core/src/Actions/Carts/CreateOrder.php
+++ b/packages/core/src/Actions/Carts/CreateOrder.php
@@ -50,7 +50,7 @@ class CreateOrder
                     return [
                         'description'       => $tax['description'],
                         'identifier'   => $tax['identifier'],
-                        'percentage' => $tax['amounts']->sum('percentage'),
+                        'percentage' => $tax['amounts']->min('percentage'),
                         'total'      => $tax['total']->value,
                     ];
                 })->values(),


### PR DESCRIPTION
Fix for #519 

We shouldn't be summing the percentage on order tax summaries, so changed to `min()` as the percentages should always be the same regardless.
